### PR TITLE
mew-unix.el: Bug fix for mew-unix-browser-arg.

### DIFF
--- a/mew-unix.el
+++ b/mew-unix.el
@@ -13,7 +13,7 @@
 (defvar mew-format-xml  "%s.xml")
 
 (defvar mew-unix-browser "firefox")
-(defvar mew-unix-browser-arg `("-a" "firefox" "-remote" "openFile(%s)"))
+(defvar mew-unix-browser-arg `("%s"))
 (defvar mew-unix-browser-form `(,mew-unix-browser ,mew-unix-browser-arg t))
 
 (defvar mew-prog-text/html           'mew-mime-text/html-w3m) ;; See w3m.el


### PR DESCRIPTION
Patch from [mew-int 2974] on 2011-03-11 for mew-unix-browser-arg
to work firefox correctly, provided by Diogo F. S. Ramos.
