### PR TITLE
.class and .jar extensions in mew-mime-content-type

### DIFF
--- a/mew-varsx.el
+++ b/mew-varsx.el
@@ -162,7 +162,7 @@
    ("application/x-zip-compressed"  "\\.zip$" mew-b64
     mew-prog-unzip                  mew-icon-application/octet-stream)
    ("application/octet-stream"
-    "\\.tar$\\|\\.tar\\.\\|\\.gz$\\|\\.Z$\\|\\.taz$\\|\\.tgz$\\|\\.tbz$\\|\\.bz2?$\\|\\.lzh$\\|\\.bin$\\|\\.pgp$\\|\\.gpg$\\|\\.exe$\\|\\.dll$"
+    "\\.tar$\\|\\.tar\\.\\|\\.jar$\\|\\.gz$\\|\\.Z$\\|\\.taz$\\|\\.tgz$\\|\\.tbz$\\|\\.bz2?$\\|\\.lzh$\\|\\.bin$\\|\\.pgp$\\|\\.gpg$\\|\\.exe$\\|\\.dll$\\|\\.class$"
     mew-b64 mew-prog-octet-stream mew-icon-application/octet-stream)
    ;;
    ("text/html"     "\\.html?$" nil     mew-prog-html      mew-icon-text)


### PR DESCRIPTION
Added .jar and .class extensions to the regexp matching the "application/octet-stream" mimetype.
