### PR TITLE
Fixing regex of mew-regex-ignore-scan-body-list

### DIFF
--- a/mew-scan.el
+++ b/mew-scan.el
@@ -521,8 +521,8 @@ Address is converted by 'mew-summary-form-extract-addr'. See also
     "^--"
     "^- --"
     "^=2D"
-    "^.*\\(:\\|;\\|/\\)[ \t]*$"
-    "^.*\\(wrote\\|writes?\\|said\\|says?\\)[^.!\n]?[ \t]*$"
+    "^.\\{1,100\\}\\(:\\|;\\|/\\)[ \t]*$"
+    "^.\\{1,100\\}\\(wrote\\|writes?\\|said\\|says?\\)[^.!\n]?[ \t]*$"
     "^[ \t]*\\(On\\|At\\) .*[^.! \t\n][ \t]*$"
     "^[ \t]*In \\(message\\|article\\|mail\\|news\\|<\\|\"\\|\\[\\|(\\)"))
 


### PR DESCRIPTION
To prevent an error "Stack overflow in regexp matcher"
reported by ishida in [mew-dist 29440] on 2012-01-27.
