### PR TITLE
Preventing that Ruby 1.9 stores blob data into id.db

### DIFF
--- a/bin/cmew
+++ b/bin/cmew
@@ -30,7 +30,7 @@ def mail_header(path)
       break if /^$/ =~ l
       if /^\s+/ !~ l
         (name, value) = l.split(/:\s*/, 2)
-        value = '' if value.nil?
+        value = '' if value.nil? || value.empty?
         @header[name.downcase] = value
       else
         value << $'


### PR DESCRIPTION
Reported by Kei Tsuji in [mew-dist 29471] on 2012-03-19, and fixed
by Tatsuya Kinoshita in [mew-dist 29477] on 2012-03-27.  See also
Ruby's bug #6206 http://bugs.ruby-lang.org/issues/6206.
