### PR TITLE
fix `mew-thread-glue' destroying file encoding.

### DIFF
--- a/mew-thread.el
+++ b/mew-thread.el
@@ -1141,11 +1141,12 @@ The thread/message is specified with the mark(\\[set-mark-command])."
 (defun mew-thread-save-xref (fld msg id)
   (with-temp-buffer
     (let ((file (mew-expand-msg fld msg)))
-      (mew-insert-file-contents2 file)
-      (mew-header-delete-lines (list mew-x-mew-ref:))
-      (goto-char (point-min))
-      (mew-header-insert mew-x-mew-ref: id)
-      (write-region (point-min) (point-max) file nil 'no-msg))))
+      (mew-plet
+       (mew-insert-file-contents2 file)
+       (mew-header-delete-lines (list mew-x-mew-ref:))
+       (goto-char (point-min))
+       (mew-header-insert mew-x-mew-ref: id)
+       (write-region (point-min) (point-max) file nil 'no-msg)))))
 
 (provide 'mew-thread)
 


### PR DESCRIPTION
Mail file contains Japanese painting char, mew may destroy file encoding.
