### PR TITLE
Summary: correct display with right-to-left "From:" or "Subject:".

### DIFF
--- a/mew-mime.el
+++ b/mew-mime.el
@@ -258,6 +258,7 @@
 					mew-use-text/html-list-type)))
 	      (progn
 		(funcall mew-prog-text/html start (point-max))
+                (delete-trailing-whitespace start (point-max))
 		(mew-highlight-body-region start (point-max)))
 	    (mew-message-for-summary "To parse HTML, type '\\[mew-summary-analyze-again]'"))))
     (insert " #     # ####### #     # #\n"


### PR DESCRIPTION
When the From: is containing right to left chars (e.g. مجموعة مملكة الايميلات البريدي), the following fields in the summary line were displayed incorrectly in Emacs 24 — which supports bidirectional display.  This patches fixes that.
