### PR TITLE
Support GnuPG 2.0.19 and work around Emacs's process handling bug

### DIFF
--- a/mew-passwd.el
+++ b/mew-passwd.el
@@ -177,6 +177,8 @@
 	      (set-process-filter   pro 'mew-passwd-filter)
 	      (set-process-sentinel pro 'mew-passwd-sentinel)
 	      (mew-passwd-rendezvous)
+	      (unless (file-exists-p tfile)
+		(setq mew-passwd-master nil))
 	      (when mew-passwd-master
 		(let ((coding-system-for-read 'undecided))
 		  (insert-file-contents tfile))


### PR DESCRIPTION
GnuPG at least 2.0.19 changed its message for wrong passphrases. This patch follows the change by modifying Mew's process filter for GnuPG.

Alas, however, that alone didn't work for me because Emacs's process filter somehow dropped the last few message lines from GnuPG. Add a work-around that checks the existence of the resulting decrypted file instead of solely relying on the unstable process filter.
