### PR TITLE
Add coding tag to clarify non-ASCII

### DIFF
--- a/mew-lang-jp.el
+++ b/mew-lang-jp.el
@@ -172,6 +172,16 @@
 (defvar mew-highlight-body-regex-cite
   "^\\(\\([ \t]\\{,7\\}\\([>:|〉＞》≫：｜]\\|\\w+\\([._-]+\\w+\\)*>+\\)\\)+\\).*")
 
+(defvar mew-regex-url
+  (concat
+   "\\b\\("
+   "\\(\\(file\\|news\\|mailto\\):\\)"
+   "\\|"
+   "\\(\\(s?https?\\|ftp\\|gopher\\|telnet\\|wais\\)://\\)"
+   "\\)"
+   "[^ 　\t\n>)\"]*"
+   "[^ 　\t\n>.,:)\"]+"))
+
 (provide 'mew-lang-jp)
 
 ;;; Copyright Notice:

--- a/mew-vars.el
+++ b/mew-vars.el
@@ -1,4 +1,3 @@
-;;-*-coding:iso-2022-jp;-*-
 ;;; mew-vars.el --- Variables and Constants for Mew
 
 ;; Author:  Kazu Yamamoto <Kazu@Mew.org>
@@ -2857,8 +2856,8 @@ in Summary/Virtual mode."
    "\\|"
    "\\(\\(s?https?\\|ftp\\|gopher\\|telnet\\|wais\\)://\\)"
    "\\)"
-   "[^ 　\t\n>)\"]*"
-   "[^ 　\t\n>.,:)\"]+")
+   "[^ \t\n>)\"]*"
+   "[^ \t\n>.,:)\"]+")
   "*Regular expression to find URL."
   :group 'mew-highlight
   :type 'regexp)


### PR DESCRIPTION
Please merge this branch to clarify mew-vars.el is encoded with iso-2022-jp.

Note: the value of mew-regex-url is garbled with the current Emacs trunk
(2013-06-18), because of broken recognition of iso-2022-*.
