### PR TITLE
Find a deep part for mew-scan-body

### DIFF
--- a/mew-scan.el
+++ b/mew-scan.el
@@ -550,11 +550,13 @@ Address is converted by 'mew-summary-form-extract-addr'. See also
 	;; (setq ctl (mew-param-decode ctr))
 	;; (setq ct (mew-syntax-get-value ctl 'cap))
 	;; So, this hard coding is used.
-	(when (and (string-match "^Multipart/" ctr)
+	(while (and (string-match "^Multipart/" ctr)
 		   (string-match "boundary=\"?\\([^\"\n\t;]+\\)\"?" ctr))
 	  (setq boundary (mew-match-string 1 ctr))
 	  (setq boundary (concat "^--" (regexp-quote boundary)))
+	  (setq found nil)
 	  (catch 'loop
+	    (setq i 0)
 	    (while (< i I)
 	      (if (looking-at boundary) (throw 'loop (setq found t)))
 	      (forward-line)


### PR DESCRIPTION
If top-level is Multipart/Mixed, No.1 part is Multipart/Alternative,
and No.1.1 part is Text/Plain, it is not found.

With this patch, No.1.1 part is found to display in Summary.
