### PR TITLE
Changed mew-regex-url to disallow right square bracket at the end.

### DIFF
--- a/mew-vars.el
+++ b/mew-vars.el
@@ -2859,7 +2859,7 @@ in Summary/Virtual mode."
    "\\(\\(s?https?\\|ftp\\|gopher\\|telnet\\|wais\\)://\\)"
    "\\)"
    "[^ \t\n>)\"]*"
-   "[^ \t\n>.,:)\"]+")
+   "[^] \t\n>.,:)\"]")
   "*Regular expression to find URL."
   :group 'mew-highlight
   :type 'regexp)


### PR DESCRIPTION
I often receive email with embedded URLs looking like [http://example.com/path]. This small change avoids final ] polluting the URL.
