### PR TITLE
Add some Content-Types

### DIFF
--- a/mew-varsx.el
+++ b/mew-varsx.el
@@ -80,14 +80,17 @@
    ("image/tiff"  "\\.tif?f$" mew-b64 mew-prog-image mew-icon-image tiff)
    ("image/jpeg"  "\\.jpe?g$" mew-b64 mew-prog-image mew-icon-image jpeg)
    ("image/pjpeg" "\\.jfif$"  mew-b64 mew-prog-image mew-icon-image jpeg) ;; MS
+   ("image/jpg"   "^$"        mew-b64 mew-prog-image mew-icon-image jpeg) ;; unofficial
    ("image/png"   "\\.png$"   mew-b64 mew-prog-image mew-icon-image png)
    ("image/x-xwd" "\\.xwd$"   mew-b64 mew-prog-image mew-icon-image xwd)
    ("image/x-xbm" "\\.xbm$"   mew-b64 mew-prog-image mew-icon-image xbm)
    ("image/x-xpm" "\\.xpm$"   mew-b64 mew-prog-image mew-icon-image xpm)
    ("image/x-bmp" "\\.bmp$"   mew-b64 mew-prog-image mew-icon-image bmp)
+   ("image/bmp"   "^$"        mew-b64 mew-prog-image mew-icon-image bmp) ;; unofficial
    ("image/x-pcx" "\\.pcx$"   mew-b64 mew-prog-image mew-icon-image PCX)
    ("image/x-tga" "\\.tga$"   mew-b64 mew-prog-image mew-icon-image TGA)
    ("image/vnd.ms-modi" "\\.mdi$" mew-b64 mew-prog-image mew-icon-image)
+   ("image/vnd.microsoft.icon" "\\.ico$" mew-b64 mew-prog-image mew-icon-image ICO)
    ("image"       "^$"        mew-b64 mew-prog-image mew-icon-image)
    ;;
    ("model/iges" "\\.ige?s$" mew-b64 mew-prog-iges  mew-icon-image) ;; xxx


### PR DESCRIPTION
image/bmp: Windows bitmap (.bmp), unofficial, IANA unregistered, Microsoft's de facto standard.
image/jpg: JPEG (.jpg), unofficial, IANA unregistered, some MUA's typo, registered type is image/jpeg.
image/vnd.microsoft.icon: Windows icon (.ico), IANA registered.
