### PR TITLE
Add internet media types of netpbm formats

### DIFF
--- a/mew-gemacs.el
+++ b/mew-gemacs.el
@@ -270,7 +270,8 @@
     (bmp  mew-bmp-size  "bmptopnm"  "ppmtobmp")
     (PCX  nil           "pcxtoppm"  "ppmtopcx")
     (TGA  nil           "tgatoppm"  "pamtotga")
-    (ICO  nil           "winicontoppm" "ppmtowinicon")))
+    (ICO  nil           "winicontoppm" "ppmtowinicon")
+    (PAM  nil           "pamtopnm"  "pamtopam")))
 
 (defun mew-image-format-ent (format)
   (assoc format mew-image-alist))

--- a/mew-varsx.el
+++ b/mew-varsx.el
@@ -91,6 +91,11 @@
    ("image/x-tga" "\\.tga$"   mew-b64 mew-prog-image mew-icon-image TGA)
    ("image/vnd.ms-modi" "\\.mdi$" mew-b64 mew-prog-image mew-icon-image)
    ("image/vnd.microsoft.icon" "\\.ico$" mew-b64 mew-prog-image mew-icon-image ICO)
+   ("image/x-portable-bitmap" "\\.pbm$" mew-b64 mew-prog-image mew-icon-image pbm)
+   ("image/x-portable-graymap" "\\.pgm$" mew-b64 mew-prog-image mew-icon-image pbm)
+   ("image/x-portable-pixmap" "\\.ppm$" mew-b64 mew-prog-image mew-icon-image pbm)
+   ("image/x-portable-anymap" "\\.pnm$" mew-b64 mew-prog-image mew-icon-image pbm)
+   ("image/x-portable-arbitrarymap" "\\.pam$" mew-b64 mew-prog-image mew-icon-image PAM)
    ("image"       "^$"        mew-b64 mew-prog-image mew-icon-image)
    ;;
    ("model/iges" "\\.ige?s$" mew-b64 mew-prog-iges  mew-icon-image) ;; xxx


### PR DESCRIPTION
-  Internet Media Type

image/x-portable-bitmap pbm
image/x-portable-graymap pgm
image/x-portable-pixmap ppm
image/x-portable-anymap pnm
image/x-portable-arbitrarymap pam

All IANA unregistered but netpbm format specifications specified them.

http://netpbm.sourceforge.net/doc/pbm.html
http://netpbm.sourceforge.net/doc/pgm.html
http://netpbm.sourceforge.net/doc/ppm.html
http://netpbm.sourceforge.net/doc/pnm.html
http://netpbm.sourceforge.net/doc/pam.html
- PAM format

Most emacsen support PBM format as image format type symbol "pbm".
It includes PGM and PPM format support, also include PNM formats support.
Therefore, emacsen can show only by internet media type addition.

But most emacsen don't support PAM format.
Then, I added the converter "pamtopnm", in the case of PAM format.
It converts PAM format to PNM formats.

On the other hand, it is not this commit,
pamscale 841bca7a7df9e236bf86a3a8a81f33035750c188 and pngtopam f5c8e3c9fc5b792f9f0ee5d4e0e020ea4bd2ad3a which may output pam format are used.
However, when input is PNM formats, pamscale outputs PNM formats and doesn't outputs PAM format.
Also, when without a command line option, pngtopam outputs PNM formats and doesn't output PAM format.
Therefore, PAM format is not passed to emacsen as it is.
