### PR TITLE
Fix function mew-image-inline-p return value

### DIFF
--- a/mew-gemacs.el
+++ b/mew-gemacs.el
@@ -159,7 +159,7 @@
   (or (and window-system (image-type-available-p format))
       (let* ((ent (mew-image-format-ent format))
 	     (prog (mew-image-get-prog ent)))
-	(and prog (mew-which-exec prog)))))
+	(and prog (mew-which-exec prog) t))))
 
 (defun mew-img-get-n (op len)
   (let* ((size 0))


### PR DESCRIPTION
function mew-image-inline-p may return strings.
It should return value t or nil only.
