### PR TITLE
Add emacs unsupported image resizing

### DIFF
--- a/mew-gemacs.el
+++ b/mew-gemacs.el
@@ -327,6 +327,11 @@
 	 (call-process-region (point-min) (point-max) prog
 			      t '(t nil) nil)
 	 (setq format 'pbm)
+	 (unless (or image-width image-height)
+	   (goto-char (point-min))
+	   (setq image-size (mew-pbm-size))
+	   (setq image-width (car image-size))
+	   (setq image-height (cdr image-size)))
 	 (message "Converting image...done"))
        (when (and image-width image-height
 		  (or (< width image-width)


### PR DESCRIPTION
Resizing was possible if there is a size obtaining function of an original image format.
ex. bmp format 1811d92f766563d37631a1e9f1fc5efaef1a0ecf

Emacs unsupported image is shown after converting the image to PNM (pbm) format.
e51f212bd310bf4d4f1009733c4d2e69df9025aa

The function which obtains the size of a PNM (pbm) format image exists.
80841f73674d0aaf44bdc6058bf6da243cef307c

So, I wrote this code. 
It obtains image size after conversion,
when original image size is unknown.

In addition, the case of emacs supported image, 
when there is not an original format image size obtaining function,
it doesn't convert to PNM format.
So, it can't resize.
(Now in my environment, xpm and xbm can't resize in this reason.)

Of course, if all image formats are converted, it can resize all of them.
However, image format conversion requires many resources.
Therefore, only in the following cases, the image resizing is enabled;
- Before this commit:
  An original format image size obtaining function exists.
  (Now, jpeg png gif tiff bmp pbm PAM)
- By this commit:
  Emacs unsupported and converter listed image.
  (Now in my environment, xwd PCX TGA ICO)

On the other hand, if a resource is abundant environment,
there is also the method of always resizing regardless of original image size.
For this purpose, I think that a flag variable
(ex. mew-image-display-resize-always) should be prepared.
If non-nil, image will be always resized.
When a image is smaller than a frame, it will expand to frame size.

Do you want such flag?
