### PR TITLE
Fix variable mew-image-display-resize ignored

### DIFF
--- a/mew-gemacs.el
+++ b/mew-gemacs.el
@@ -314,7 +314,8 @@
        (insert-buffer-substring cache begin end)
        (mew-set-buffer-multibyte nil)
        (goto-char (point-min))
-       (cond (func-size
+       (cond ((and mew-image-display-resize
+		   func-size)
 	      (setq image-size (funcall func-size))
 	      (setq image-width (car image-size))
 	      (setq image-height (cdr image-size)))
@@ -333,7 +334,8 @@
 	   (setq image-width (car image-size))
 	   (setq image-height (cdr image-size)))
 	 (message "Converting image...done"))
-       (when (and image-width image-height
+       (when (and mew-image-display-resize
+		  image-width image-height
 		  (or (< width image-width)
 		      (and mew-image-display-resize-care-height (< height image-height)))
 		  (or (eq format 'pbm) (mew-which-exec prog)))


### PR DESCRIPTION
The variable `mew-image-display-resize` was ignored and did not performed.
Maybe it has been from mew-6.2.52 (2009/08/12).
(It is before from github initial import.)

Now, if the variable is non-nil,
the image that is larger than frame size will be displayed with fitting to frame size.
The image that is smaller than frame size will be displayed in size as it is.
