### PR TITLE
Add image resizing always flag

### DIFF
--- a/mew-gemacs.el
+++ b/mew-gemacs.el
@@ -355,7 +355,7 @@
 	 (if mew-image-display-resize-care-height
 	     (call-process-region (point-min) (point-max) "pamscale"
 				  t '(t nil) nil
-				  "-xysize"
+				  "-xyfit"
 				  (format "%d" width)
 				  (format "%d" height))
 	   (call-process-region (point-min) (point-max) "pamscale"


### PR DESCRIPTION
This commit defined variable `mew-image-display-resize-always`.
If nil, only a larger image than frame size will be displayed with fitting to frame size.
If non-nil, the image of all the sizes will be displayed with fitting to frame size.

The default is nil.
Because, image format conversion and resizing requires many resources.
If your machine has a lot of resources, you can set t to the variable in your .mew file.

The behavior by a flag etc. is as follows.

<table border="1">
<tr>
 <th rowspan="4" colspan="2"></th>
 <th colspan="4">flags / function</th>
</tr>
<tr>
 <th colspan="3">mew-image-resize-display t</th>
 <th rowspan="3">mew-image-resize-dispaly nil</th>
</tr>
<tr>
 <th rowspan="2">mew-image-resize-display-always t</th>
 <th colspan="2">mew-image-resize-display-always nil</th>
</tr>
<tr>
 <th>image size obtaining function exist</th>
 <th>image size obtaining function do not exist</th>
</tr>
<tr>
 <th rowspan="2">image</th>
 <th>smaller than frame size</th>
 <td>enlarge to frame size</td>
 <td>size as it is</td>
 <td>size as it is</td>
 <td>size as it is</td>
</tr>
<tr>
 <th>larger than frame size</th>
 <td>reduce to frame size</td>
 <td>reduce to frame size</td>
 <td>size as it is</td>
 <td>size as it is</td>
</tr>
</table>

