### PR TITLE
Update mew-regex-ignore-scan-body-list for a line beginning with "["

### DIFF
--- a/mew-scan.el
+++ b/mew-scan.el
@@ -514,7 +514,7 @@ Address is converted by 'mew-summary-form-extract-addr'. See also
 (defvar mew-regex-ignore-scan-body-list
   '("^[ \t]*$"
     "^[ \t]*[-a-zA-Z0-9]+: "
-    "^[ \t]*[>:|#;/_}]"
+    "^[ \t]*[[>:|#;/_}]"
     "^[ \t]*\\w+\\(['._-]+\\w+\\)*>"
     "^[ \t]*[[</(.-]+ *\\(snip\\|\\.\\.\\)"
     "^   "


### PR DESCRIPTION
Please merge this patch not to display a line beginning with "[" in Summary.

e.g. http://lists.gnu.org/archive/html/emacs-devel/2014-01/msg01657.html
displays "[[[ To any NSA and FBI ..." in Summary.  With this patch,
"I don't know why ..." is displayed.
