### PR TITLE
Add "failed" message when pdftotext does not exist

### DIFF
--- a/mew-mime.el
+++ b/mew-mime.el
@@ -592,7 +592,8 @@
     (if (not doit)
 	(progn
 	  (mew-elet (insert "\n"))
-	  (mew-mime-part-messages t))
+	  (mew-mime-part-messages t)
+	  (message "Displaying a PDF document...failed"))
       (setq file1 (mew-make-temp-name))
       (with-current-buffer cache
 	(mew-flet


### PR DESCRIPTION
This is about displaying a PDF attached file. 

When pdftotext does not exist, even if processing is completed,
the echo area continues showing "Displaying a PDF document..."

So, this commit adds "Displaying a PDF document...failed" message.
