### PR TITLE
mew-summary-refile-report: Show warning when mew-header-reasonable-size does not cover the header of the selected message.

### DIFF
--- a/mew-refile.el
+++ b/mew-refile.el
@@ -756,10 +756,11 @@ with '\\[universal-argument]', it displays how the refile rules work in Message 
 	(customize-var '(mew-refile-ctrl-multi
 			 mew-refile-guess-key-list
 			 mew-refile-guess-strip-domainpart
-			 mew-refile-guess-from-me-is-special))
+			 mew-refile-guess-from-me-is-special
+			 mew-header-reasonable-size))
 	mew-inherit-refile-case
 	mew-inherit-refile-proto
-	fld msg guess)
+	fld msg guess boundary)
     (save-excursion
       (mew-summary-goto-message)
       (when (mew-sumsyn-match mew-regex-sumsyn-short)
@@ -771,6 +772,9 @@ with '\\[universal-argument]', it displays how the refile rules work in Message 
     (with-temp-buffer
       (mew-insert-message
        fld msg mew-cs-text-for-read mew-header-reasonable-size)
+      (save-excursion
+	(goto-char (point-min))
+	(setq boundary (search-forward "\n\n" nil t)))
       (mew-refile-decode-subject)
       (setq guess (mew-refile-guess nil t)))
     (mew-window-configure 'message)
@@ -785,6 +789,8 @@ with '\\[universal-argument]', it displays how the refile rules work in Message 
        (dolist (cvar customize-var)
 	 (insert (format "%-40s:  " cvar))
 	 (insert (format "%s\n"     (eval cvar))))
+       (unless boundary
+	 (insert "Warning: Not analyzing whole header. You may need to increase mew-header-reasonable-size\n"))
        (insert "\n** Each function's opinion:\n\n")
        ;; report how each functions guessed.
        (setq guess (cdr guess))


### PR DESCRIPTION
Refiling does not work as expected when the message header is longer than mew-header-reasonable-size. But mew-summary-refile-report does not say about this and make it hard to track down this configuration problem.

This patch shows warning about this. It also shows mew-header-reasonable-size in Current configurations section.

It might be better to read additional block of the message when their is no blank line in mew-summary-refile-body, and abandon mew-header-reasonable-size. But if the default is `reasonable`, this is kind of corner case so I think making it detectable will be enough.  (and the additional hack may not be done cleanly with my elisp skill.)
