### PR TITLE
Choose last preferred part in multipart/alternative

### DIFF
--- a/mew-decode.el
+++ b/mew-decode.el
@@ -854,10 +854,10 @@ Return a part syntax after moving the beginning of the content body."
 	(atpref (mew-mime-external-body-preference part)))
     ;; returns '(prefpart lastpref lastatpref)
     (cond
-     ((or (null prefpart) (< pref lastpref))
+     ((or (null prefpart) (<= pref lastpref))
       (list part pref atpref))
      ((and (= pref lastpref) atpref
-	   (or (null lastatpref) (< atpref lastatpref)))
+	   (or (null lastatpref) (<= atpref lastatpref)))
       ;; If external-body and internal-body are alternative,
       ;; what should we do?
       (list part lastpref atpref))


### PR DESCRIPTION
cf. https://github.com/wanderlust/wanderlust/issues/60

> Subject: [PATCH] Use last highest score part in multipart/alternative.
> 
> RFC 2046 paragraph 5.1.4 says:
> 
>   Receiving user agents should pick and display the last format
>   they are capable of displaying.
