### PR TITLE
Fix continual failure of mew-passwd-load function

### DIFF
--- a/mew-passwd.el
+++ b/mew-passwd.el
@@ -177,9 +177,8 @@
 	      (set-process-filter   pro 'mew-passwd-filter)
 	      (set-process-sentinel pro 'mew-passwd-sentinel)
 	      (mew-passwd-rendezvous)
-	      (unless (file-exists-p tfile)
-		(setq mew-passwd-master nil))
-	      (when mew-passwd-master
+	      (if (not (file-exists-p tfile))
+		  (setq mew-passwd-master nil)
 		(let ((coding-system-for-read 'undecided))
 		  (insert-file-contents tfile))
 		(condition-case nil


### PR DESCRIPTION
Gpg version 2 can decrypt an encrypted file without asking for a
passphrase if it is cached in a gpg-agent process.

When a master password is not set to mew-passwd-master variable and
gpg can get the password from gpg-agent, mew-passwd-load function
always fails outputting "Master password is wrong!" because the
decryption of mew-passwd-file succeeds without setting
mew-passwd-master variable.

This happens, for instance, in the following situation:
1. invoke mew and make an imap/smtp connection.
   -> mew-passwd-load function is called, and gpg program is invoked
      to decrypt existing passwords of imap and smtp.
   -> gpg asks for a master password and tells it to gpg-agent.
   -> mew-passwd-load saves the master password in mew-passwd-master
      through mew-passwd-filter, and successfully returns the decrypted
      imap/smtp passwords.
2. once exit mew
3. invoke mew again and try to make an imap/smtp connection.
   -> mew-passwd-load function invokes gpg.
   -> gpg gets the master password from gpg-agent and decrypts
      mew-passwd-file without asking for any passwords, leading to
      mew-passwd-master being nil.
   -> mew-passwd-load aborts and does not return the decrypted imap/smtp
      passwords.

The failure continues until user kills the gpg-agent process or the
cached passphrase will expire.

This patch fixes the issue by changing mew-passwd-load function so
that it tries to read the output of gpg program even if
mew-passwd-master is not set.
