### PR TITLE
Do not use exit|return with negative status code to fix bashism

### DIFF
--- a/bin/mewest
+++ b/bin/mewest
@@ -60,7 +60,7 @@ check_cygwin () {
     then
         true
     else
-        return -1
+        return 255
     fi
     case `uname -s` in
     CYGWIN*)
@@ -68,7 +68,7 @@ check_cygwin () {
         then
             return 1
         else
-            return -1
+            return 255
         fi
         ;;
     *)
@@ -101,7 +101,7 @@ case $? in
     ;;
 *)
     echo Environment check failed
-    exit -1
+    exit 255
     ;;
 esac
 


### PR DESCRIPTION
cf. https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=772311
