### PR TITLE
How to set mew-prog-ssl-arg for stunnel v5

### DIFF
--- a/mew-ssl.el
+++ b/mew-ssl.el
@@ -27,9 +27,9 @@ A file name of a certificate should be 'cert-hash.0'.
 
 (defvar mew-prog-ssl-arg nil
   "For stunnel v3, a list of command-line arguments, each one a string.
-For stunnel v4, a string of extra text to place in the configuration file,
-which should end with a newline (example: \"fips=no\\n\"); or nil to insert
-no extra text.")
+For stunnel v4 or v5, a string of extra text to place in the configuration
+file, which should end with a newline (example: \"fips=no\\n\"); or nil to
+insert no extra text.")
 
 (defvar mew-ssl-ver nil)
 (defvar mew-ssl-minor-ver nil)


### PR DESCRIPTION
This change updates the documentation to mention stunnel v5 as well as v3 and v4.