### PR TITLE
Improve regex in mew-search(-virtual)-with-est

### DIFF
--- a/mew-search.el
+++ b/mew-search.el
@@ -548,7 +548,7 @@ with a search method."
 
 (defun mew-search-with-est (pattern folder filter)
   (let* ((path (mew-expand-folder folder))
-	 (regex (format "file://.*/%s/.*/\\([0-9]+\\)\\(%s\\)?$"
+	 (regex (format "file://.*?/%s/.*/\\([0-9]+\\)\\(%s\\)?$"
 			(file-name-nondirectory mew-mail-path)
 			(regexp-quote mew-suffix)))
 	 msgs)
@@ -564,7 +564,7 @@ with a search method."
       (mapcar 'number-to-string msgs))))
 
 (defun mew-search-virtual-with-est (pattern flds filter)
-  (let* ((regex (format "file://.*/%s/\\(.*\\)/\\([0-9]+\\)\\(%s\\)?$"
+  (let* ((regex (format "file://.*?/%s/\\(.*\\)/\\([0-9]+\\)\\(%s\\)?$"
 			(file-name-nondirectory mew-mail-path)
 			(regexp-quote mew-suffix)))
 	 (file (mew-make-temp-name))


### PR DESCRIPTION
Use non-greedy matching when extracting the path to the local mail
directory from Hyper Estraier search results. Greedy matching leeds to
problems when the deepest directory in mew-mail-path has the same name
as a directory on an IMAP mail server.