### PR TITLE
Change the default program to open office documents on Unix

### DIFF
--- a/dot.mew
+++ b/dot.mew
@@ -153,16 +153,7 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
-;;; Using OpenOffice.org (openoffice)
-;;;
-
-;(setq mew-prog-msword '("openoffice" nil t))
-;(setq mew-prog-msexcel '("openoffice" nil t))
-;(setq mew-prog-mspowerpoint '("openoffice" nil t))
-
-;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;;;
-;;; Using StarSuite (soffice)
+;;; Using Apache OpenOffice / LibreOffice / StarSuite
 ;;;
 
 ;(setq mew-prog-msword '("soffice" nil t))

--- a/info/mew.info-3
+++ b/info/mew.info-3
@@ -1444,18 +1444,18 @@ If you want to set it to "firefox", for example, configure like this:
 
 You can visualize an Office-family file to each application by typing
 `C-cC-e'. On Windows and Mac, an Office-family application is
-executed. On Unix, "ooffice" is set to the default application as
+executed. On Unix, "soffice" is set to the default application as
 follows:
 
-     (defvar mew-prog-msword-ext "ooffice")
-     (defvar mew-prog-msexcel-ext "ooffice")
-     (defvar mew-prog-mspowerpoint-ext "ooffice")
+     (defvar mew-prog-msword-ext "soffice")
+     (defvar mew-prog-msexcel-ext "soffice")
+     (defvar mew-prog-mspowerpoint-ext "soffice")
 
-If you want to set it to "soffice", for instace, do like this:
+If you want to set it to "xdg-open", for instace, do like this:
 
-     (setq mew-prog-msword-ext "soffice")
-     (setq mew-prog-msexcel-ext "soffice")
-     (setq mew-prog-mspowerpoint-ext "soffice")
+     (setq mew-prog-msword-ext "xdg-open")
+     (setq mew-prog-msexcel-ext "xdg-open")
+     (setq mew-prog-mspowerpoint-ext "xdg-open")
 
 If you want to not visualize an Office-family file into the Message
 buffer, but want to display it with "wvHtml", configure as follows:

--- a/info/mew.ja.info-2
+++ b/info/mew.ja.info-2
@@ -2095,18 +2095,18 @@ HTML は `C-cC-e' を使って外部のブラウザに表示できます。Windo
 
 Office 関連のファイルも、`C-cC-e' を使えば、それぞれのアプリケーション
 で表示可能です。Windows や Mac では、文字通り Office のアプリケーショ
-ンが起動されます。Unix では、以下のように "ooffice" が初期値となってい
+ンが起動されます。Unix では、以下のように "soffice" が初期値となってい
 ます。
 
-     (defvar mew-prog-msword-ext "ooffice")
-     (defvar mew-prog-msexcel-ext "ooffice")
-     (defvar mew-prog-mspowerpoint-ext "ooffice")
+     (defvar mew-prog-msword-ext "soffice")
+     (defvar mew-prog-msexcel-ext "soffice")
+     (defvar mew-prog-mspowerpoint-ext "soffice")
 
-これを "soffice" に変更するには以下のようにします。
+これを "xdg-open" に変更するには以下のようにします。
 
-     (setq mew-prog-msword-ext "soffice")
-     (setq mew-prog-msexcel-ext "soffice")
-     (setq mew-prog-mspowerpoint-ext "soffice")
+     (setq mew-prog-msword-ext "xdg-open")
+     (setq mew-prog-msexcel-ext "xdg-open")
+     (setq mew-prog-mspowerpoint-ext "xdg-open")
 
 また Office 関連のアプリケーションに対し、`SPC' などでは内容を表示せず、
 `C-cC-e' では "wvHtml" などを使って Message バッファに表示するには、以

--- a/info/mew.texi
+++ b/info/mew.texi
@@ -10428,33 +10428,33 @@ If you want to set it to "firefox", for example, configure like this:
 @ifset ja
 Office 関連のファイルも、@samp{C-cC-e} を使えば、それぞれのアプリケーショ
 ンで表示可能です。Windows や Mac では、文字通り Office のアプリケーショ
-ンが起動されます。Unix では、以下のように "ooffice" が初期値となってい
+ンが起動されます。Unix では、以下のように "soffice" が初期値となってい
 ます。
 @end ifset
 @ifset en
 You can visualize an Office-family file to each application by typing
 @samp{C-cC-e}. On Windows and Mac, an Office-family application is
-executed. On Unix, "ooffice" is set to the default application as
+executed. On Unix, "soffice" is set to the default application as
 follows:
 @end ifset
 
 @lisp
-(defvar mew-prog-msword-ext "ooffice")
-(defvar mew-prog-msexcel-ext "ooffice")
-(defvar mew-prog-mspowerpoint-ext "ooffice")
+(defvar mew-prog-msword-ext "soffice")
+(defvar mew-prog-msexcel-ext "soffice")
+(defvar mew-prog-mspowerpoint-ext "soffice")
 @end lisp
 
 @ifset ja
-これを "soffice" に変更するには以下のようにします。
+これを "xdg-open" に変更するには以下のようにします。
 @end ifset
 @ifset en
-If you want to set it to "soffice", for instace, do like this:
+If you want to set it to "xdg-open", for instace, do like this:
 @end ifset
 
 @lisp
-(setq mew-prog-msword-ext "soffice")
-(setq mew-prog-msexcel-ext "soffice")
-(setq mew-prog-mspowerpoint-ext "soffice")
+(setq mew-prog-msword-ext "xdg-open")
+(setq mew-prog-msexcel-ext "xdg-open")
+(setq mew-prog-mspowerpoint-ext "xdg-open")
 @end lisp
 
 @ifset ja

--- a/mew-unix.el
+++ b/mew-unix.el
@@ -87,7 +87,7 @@
 ;;; Office
 ;;;
 
-(defvar mew-prog-ooffice "ooffice")
+(defvar mew-prog-ooffice "soffice")
 
 (defvar mew-prog-application/msword "wvHtml")
 (defvar mew-prog-msword-ext mew-prog-ooffice)


### PR DESCRIPTION
... from "ooffice" to "soffice", which is provided by every major fork of 
deceased OpenOffice.org, such as Apache OpenOffice [1] and 
LibreOffice [2].

At the same time, mention xdg-open [3] in documentation to describe
how to specify an alternative program.

[1] https://wiki.openoffice.org/wiki/Documentation/OOoAuthors_User_Manual/Getting_Started/Starting_from_the_command_line
[2] https://help.libreoffice.org/Common/Starting_the_Software_With_Parameters
[3] https://portland.freedesktop.org/doc/xdg-open.html