### PR TITLE
IMAP to support Gmail extension

### DIFF
--- a/mew-const.el
+++ b/mew-const.el
@@ -83,6 +83,10 @@
 (defconst mew-x-mew-uidl:  "X-Mew-Uidl:")
 (defconst mew-x-mew-ref:   "X-Mew-Ref:")
 
+(defconst mew-x-gm-msgid:  "X-GM-MSGID:")
+(defconst mew-x-gm-thrid:  "X-GM-THRID:")
+(defconst mew-x-gm-labels: "X-GM-LABELS:")
+
 (defconst mew-keywords: "Keywords:")
 (defconst mew-body:	"Body:")
 

--- a/mew-scan.el
+++ b/mew-scan.el
@@ -664,6 +664,27 @@ Address is converted by 'mew-summary-form-extract-addr'. See also
 	(mew-header-delete-lines (list mew-x-mew-uidl:)))
       (mew-header-insert mew-x-mew-uidl: fields 'no-fold))))
 
+(defun mew-header-insert-x-gm-labels (labels)
+  (save-excursion
+    (mew-header-delete-lines (list "X-GM-LABELS:"))
+    (mew-header-insert "X-GM-LABELS:" labels 'no-fold)))
+
+(defun mew-header-insert-x-gm-msgid (msgid)
+  (save-excursion
+    (mew-header-delete-lines (list "X-GM-MSGID:"))
+    (mew-header-insert
+     "X-GM-MSGID:"
+     (format "%x" (string-to-number msgid))
+     'no-fold)))
+
+(defun mew-header-insert-x-gm-thrid (thrid)
+  (save-excursion
+    (mew-header-delete-lines (list "X-GM-THRID:"))
+    (mew-header-insert
+     "X-GM-THRID:"
+     (format "%x" (string-to-number thrid))
+     'no-fold)))
+
 (defun mew-scan-message-truncatedp ()
   (mew-msg-truncatedp (mew-scan-uid-size (MEW-UID))))
 

--- a/mew-varsx.el
+++ b/mew-varsx.el
@@ -23,6 +23,7 @@
        mew-subj: mew-date: mew-from: mew-to: mew-cc:
        mew-ct: mew-cte: mew-x-mew-uidl:
        mew-message-id: mew-in-reply-to: mew-references: mew-x-mew-ref:
+       mew-x-gm-msgid: mew-x-gm-thrid: mew-x-gm-labels:
        mew-spam: "Body"))
 
 (mew-defvar
@@ -30,6 +31,7 @@
  '("FLD" "NUM" "SUBJ" "DATE" "FROM" "TO" "CC"
    "CT" "CTE" "UID"
    "ID" "IRT" "REF" "XREF"
+   "GM-MSGID" "GM-THRID" "GM-LABELS"
    "SPAM" "BODY"))
 
 ;;


### PR DESCRIPTION
Gmail IMAP server has its own extensions:
https://developers.google.com/gmail/imap/imap-extensions

This PR supports these features:
+ Access to the Gmail unique message ID: X-GM-MSGID
+ Access to the Gmail thread ID: X-GM-THRID
+ Access to Gmail labels: X-GM-LABELS

This PR enables Mew to:
 1. Check existence of IMAP capability X-GM-EXT-1
 2. Insert X-GM-MSGID, X-GM-THRID, X-GM-LABELS fields in fetched mails

This PR would be useful for linking Gmail world to Mew.