### PR TITLE
Supporting stunnel 5.45

### DIFF
--- a/mew-ssl.el
+++ b/mew-ssl.el
@@ -241,7 +241,7 @@ A local port number can be obtained the process name after ':'. "
       (mew-ssl-set-string pnm string)
       (setq string (concat prev-str string))
       (cond
-       ((string-match "Negotiated \\|opened with SSL" string)
+       ((string-match "Negotiated \\| ciphersuite:\\|opened with SSL" string)
 	(mew-ssl-set-status pnm t))
        ((string-match "Failed to initialize" string)
 	(mew-ssl-set-status pnm t)) ;; xxx

--- a/mew-ssl.el
+++ b/mew-ssl.el
@@ -118,7 +118,7 @@ insert no extra text.")
 	(insert (format "[%d]\n" localport))
 	(insert (format "accept=%s:%d\n" mew-ssl-localhost localport))
 	(insert (format "connect=%s:%d\n" server remoteport))
-	(if tls (insert (format "protocol=%s\nsslVersion=TLSv1\n" tls)))
+	(if tls (insert (format "protocol=%s\n" tls)))
 	(mew-frwlet mew-cs-dummy mew-cs-text-for-write
 	  ;; NEVER use call-process-region for privacy reasons
 	  (write-region (point-min) (point-max) file nil 'no-msg))


### PR DESCRIPTION
Because of the change of print_cipher() in stunnel.

  - stunnel 5.45: TLSv1 ciphersuite: ...
  - stunnel 5.44: Negotiated TLSv1 ciphersuite ...
  - stunnel 4.20: Negotiated ciphers: ...
