### PR TITLE
Don't add destination folder to mew-refile-{msgid,from}-alist if it is mew-imap-spam-folder.

### DIFF
--- a/mew-refile.el
+++ b/mew-refile.el
@@ -424,10 +424,11 @@ values."
 			   (and (member csn (car oho)) (throw 'find t))
 			   (setq oho (cdr oho))))))
 	      (throw 'match (setq folder csn)))))
-      (setq mew-refile-msgid-alist
-	    (cons (list msgid folder "??")
-		  (delq (assoc msgid mew-refile-msgid-alist) ;; delq is right
-			mew-refile-msgid-alist))))))
+      (if (and folder (not (string= folder (mew-imap-spam-folder))))
+	  (setq mew-refile-msgid-alist
+		(cons (list msgid folder "??")
+		      (delq (assoc msgid mew-refile-msgid-alist) ;; delq is right
+			    mew-refile-msgid-alist)))))))
 
 (defun mew-refile-guess-by-from-learn (chosen info)
   ;; Create mew-refile-from-alist for mew-refile-guess-by-from.
@@ -457,8 +458,8 @@ values."
 	  (unless (mew-member* csn info)
 	    (throw 'match (setq folder csn)))))
       (run-hooks 'mew-refile-guess-by-from-learn-hook)
-      ;; If candidate was found, I memorize it.
-      (when folder
+      ;; If candidate was found and it is not spam folder for IMAP, I memorize it.
+      (when (and folder (not (string= folder (mew-imap-spam-folder))))
 	(setq mew-refile-from-alist
 	      (cons (cons from folder)
 		    (delq (assoc from mew-refile-from-alist) ;; delq is right


### PR DESCRIPTION
There are some IMAP implementations that learn spam and ham by refiling message from/to spam folder (e.g. Gmail). When refiling spam message to spam folder on such IMAP implementations, there is no advantage to add destination folder (= spam folder) to `mew-refile-{msgid,from}-alist` because

1. Spam messages are seldom sent as reply to other spam message.
2. 'From' address of spam messages is often randomly genereated one  and never used again.
3. 'From' address of spam messages is sometimes same as its  destination. In this case adding 'From' address and destination  folder to mew-refile-from-alist means that messages composed by  user is suggested to refile spam folder.

So don't add destination folder to `mew-refile-{msgid,from}-alist` if it is `mew-imap-spam-folder`.