### PR TITLE
Fix mew-attach-pgp-public-key fails with gpg2

### DIFF
--- a/mew-pgp.el
+++ b/mew-pgp.el
@@ -205,7 +205,7 @@ Set 1 if 5. Set 2 if 6. Set 3 if GNUPG. Set 4 if GNUPG2.")
 ;; 2: ERROR: or Error:
 
 (defconst mew-pgp-msg-no-export-key
-  '("Key not found" "No keys" "Key not found" "nothing exported"))
+  '("Key not found" "No keys" "Key not found" "nothing exported" "nothing exported"))
 
 (defvar mew-pgp-micalg '("pgp-md5" "pgp-sha1" "pgp-sha1" "pgp-sha1" "pgp-sha1"))
 


### PR DESCRIPTION
Added an entry to mew-pgp-msg-no-export-key for gpg2.  It's same as gpg1.

```
$ gpg1 --version | head -1
gpg (GnuPG) 1.4.23
$ gpg1 --export --armor --batch UNMATCH
gpg: WARNING: nothing exported
$ gpg2 --version | head -1
gpg (GnuPG) 2.2.12
$ gpg2 --export --armor --batch UNMATCH
gpg: WARNING: nothing exported
```

cf. https://groups.google.com/forum/#!topic/mew-ja/J2X9QMBTPIM
