### PR TITLE
Fix comparison between pointer and zero character constant in mewl.c

### DIFF
--- a/bin/mewl.c
+++ b/bin/mewl.c
@@ -262,7 +262,7 @@ ch_folder(char *folder) {
 	switch (c) {
 	case '+':
 		ch_mail_home(Mail_home);
-		if (p == NUL)
+		if (*p == NUL)
 			break;
 		if (chdir(p) != 0) {
 			if( no_fld_flag != 0 )


### PR DESCRIPTION
Fix comparison between pointer and zero character constant in `mewl.c`.

```
gcc -c  -g -O2 -Wall  mewl.c
mewl.c: In function 'ch_folder':
mewl.c:265:9: warning: comparison between pointer and zero character constant [-Wpointer-compare]
   if (p == NUL)
         ^~
```