### PR TITLE
Match exactly on an email address for mew-attach-pgp-public-key

### DIFF
--- a/mew-pgp.el
+++ b/mew-pgp.el
@@ -1059,6 +1059,7 @@ Set 1 if 5. Set 2 if 6. Set 3 if GNUPG. Set 4 if GNUPG2.")
 	(setq file (file-name-nondirectory filepath))
 	(setq user (car (mew-input-address
 			 "Who's key? (%s): " (mew-get-my-address))))
+	(if (string-match "^[^<].*@" user) (setq user (concat "<" user ">")))
 	(with-temp-buffer
 	  (apply 'mew-call-process-lang
 		 (mew-pgp-get mew-prog-pgpk)


### PR DESCRIPTION
When I enter `berto@debian.org` in mew-attach-pgp-public-key,
berto@debian.org and eriberto@debian.org are used because of
partial matching.  So, it should be `<berto@debian.org>`,
around with `<` and `>`.

cf. https://github.com/kazu-yamamoto/Mew/issues/77
