### PR TITLE
Pick a subject sentence for gitlog2mewchanges

### DIFF
--- a/gitlog2mewchanges
+++ b/gitlog2mewchanges
@@ -45,6 +45,7 @@ sub print_entry {
     $comment =~ s/\n+$//;
     $comment =~ s/\n/\n  /g;
     $comment =~ s/^[-*] //;
+    $comment =~ s/\.(  |\n).*/./s;
     print "$comment\n";
 
     my $name = $author;


### PR DESCRIPTION
This commit will change the output of gitlog2mewchanges

```
* Fix the port number selection algorithm when mew-*-ssl is enabled.
  It had a bug which prevented config-alist from working.
	Hiroki Sato <hrs>
* Add GnuTLS support for SMTP, IMAP, POP, and NNTP.  The mew-*-ssl
  variables now accept the following symbols:
	Hiroki Sato <hrs>
* Add support for unix domain socket.  When "service" is specified
  in the format "^/.*", it is recognized as a unix domain socket
  and the address family becomes 'local.
	Hiroki Sato <hrs>
```

to

```
* Fix the port number selection algorithm when mew-*-ssl is enabled.
	Hiroki Sato <hrs>
* Add GnuTLS support for SMTP, IMAP, POP, and NNTP.
	Hiroki Sato <hrs>
* Add support for unix domain socket.
	Hiroki Sato <hrs>
```

cf. https://github.com/hrs-allbsd/Mew
