### PR TITLE
Fix 'no info dir entry' warning when installing info files with MSYS2

### DIFF
--- a/info/Makefile
+++ b/info/Makefile
@@ -51,8 +51,9 @@ info:
 	mv tmp.texi mew.texi
 	$(RM) mew.info*
 	$(TOUCH) mew.info
-	$(EMACS) -batch -q -no-site-file -l texinfmt \
-		-f batch-texinfo-format mew.texi
+	$(EMACS) -batch -q -no-site-file \
+		--eval "(set-default-coding-systems 'utf-8-unix)" \
+		-l texinfmt -f batch-texinfo-format mew.texi
 
 jinfo:
 	sed -e 's/@setfilename mew.info/@setfilename mew.ja.info/' \
@@ -60,8 +61,9 @@ jinfo:
 	mv tmp.texi mew.texi
 	$(RM) mew.ja.info*
 	$(TOUCH) mew.ja.info
-	$(EMACS) -batch -q -no-site-file -l texinfmt \
-		-f batch-texinfo-format mew.texi
+	$(EMACS) -batch -q -no-site-file \
+		--eval "(set-default-coding-systems 'utf-8-unix)" \
+		-l texinfmt -f batch-texinfo-format mew.texi
 
 install: install-info
 install-info:


### PR DESCRIPTION
I use Mew with following environment.

* 64bit Windows 10 version 1909
* MSYS2
* Emacs 26.3 built from source files using MSYS2
* Source files of Mew checked out from Git repository

When I execute `make info` on above environment, mew.info is generated with coding system of `japanese-shift-jis-dos`. And if I run `make install-info` after that, install-info complains as following.

> (MINGW64)yasu@rolling[2217]% make install-info
> cd info; make install-info infodir=c:/Emacs/share/info DESTDIR=
> make[1]: Entering directory '/c/Users/yasu/Work/Emacs/Mew/info'
> install-info: warning: no info dir entry in `mew.info'
> make[1]: Leaving directory '/c/Users/yasu/Work/Emacs/Mew/info'
> (MINGW64)yasu@rolling[2218]%

Same warning also happens with `make jinfo` and `make install-jinfo`. It seems `install-info` command can't handle DOS style line break properly. So explicitly specify coding system with Unix style line break when generating info files.
