### PR TITLE
Support checkHost for stunnel 5.15

### DIFF
--- a/mew-ssl.el
+++ b/mew-ssl.el
@@ -37,6 +37,7 @@ insert no extra text.")
 (defvar mew-ssl-libwrap nil)
 (defvar mew-ssl-unixlike nil
   "Set to t when stunnel supports \"foreground\" option.")
+(defvar mew-ssl-checkhost nil)
 
 (defconst mew-ssl-process-exec-cnt 3)
 
@@ -109,6 +110,8 @@ insert no extra text.")
 	(if mew-ssl-unixlike
 	    (insert "pid=\n"))
 	(insert (format "verify=%d\n" (mew-ssl-verify-level case)))
+	(if (and (> (mew-ssl-verify-level case) 0) mew-ssl-checkhost)
+	    (insert (format "checkHost=%s\n" server)))
 	(if mew-ssl-unixlike
 	    (insert "foreground=yes\n"))
 	(insert "debug=debug\n")
@@ -283,7 +286,9 @@ A local port number can be obtained the process name after ':'. "
       (when (re-search-forward "LIBWRAP" nil t)
 	(setq mew-ssl-libwrap t))
       (when (re-search-forward "foreground" nil t)
-	(setq mew-ssl-unixlike t)))))
+	(setq mew-ssl-unixlike t))
+      (when (re-search-forward "checkHost" nil t)
+	(setq mew-ssl-checkhost t)))))
 
 (provide 'mew-ssl)
 


### PR DESCRIPTION
This patch will check the peer certificate subject when
mew-ssl-verify-level is non-zero with stunnel >=5.15 and
OpenSSL >=1.0.2.

cf. https://www.stunnel.org/NEWS.html
> Version 5.21, 2015.07.27, urgency: MEDIUM
>   - More elaborate descriptions were added to the warning about
>     using "verify = 2" without "checkHost" or "checkIP".
> 
> Version 5.15, 2015.04.16, urgency: LOW
>   - Added new service-level options "checkHost", "checkEmail" and
>     "checkIP" for additional checks of the peer certificate subject.
>     These options require OpenSSL version 1.0.2 or higher.
