### PR TITLE
Fix bug that mew-passwd-gpg-version doesn't work as is expected on Windows

### DIFF
--- a/mew-passwd.el
+++ b/mew-passwd.el
@@ -63,7 +63,7 @@
 ;;;
 
 (defun mew-passwd-gpg-version ()
-  (when (mew-which mew-prog-passwd exec-path)
+  (when (mew-which-exec mew-prog-passwd)
     (with-temp-buffer
       (call-process mew-prog-passwd nil t nil "--version")
       (goto-char (point-min))


### PR DESCRIPTION
On Windows `mew-passwd-gpg-version` doesn't work as is expected because executable file of GnuPG is not `gpg` but `gpg.exe`. So fix it by using `mew-which-exec` instead of `mew-which`.