### PR TITLE
Stop using `message-box` on Windows to report that password is wrong.

### DIFF
--- a/mew-nntp2.el
+++ b/mew-nntp2.el
@@ -334,7 +334,9 @@
 	  (set-buffer buf)
 	  (mew-nntp2-queue case error))
 	(mew-nntp2-log pnm error)
-	(message-box (format "%s  This mail has been queued to %s" error qfld)))
+	(if (memq system-type '(windows-nt ms-dos cygwin))
+	    (message (format "%s  This mail has been queued to %s" error qfld))
+	  (message-box (format "%s  This mail has been queued to %s" error qfld))))
        (done
 	(message "Posting in background...done"))
        (t

--- a/mew-smtp.el
+++ b/mew-smtp.el
@@ -623,7 +623,10 @@
 	  (set-buffer buf)
 	  (mew-smtp-queue case error pnm))
 	(mew-smtp-log pnm error)
-	(message-box (format "%s  This mail has been queued to %s" error qfld)))
+
+	(if (memq system-type '(windows-nt ms-dos cygwin))
+	    (message (format "%s  This mail has been queued to %s" error qfld))
+	  (message-box (format "%s  This mail has been queued to %s" error qfld))))
        (done
 	(message "Sending in background...done"))
        (t


### PR DESCRIPTION
This fixes #141.