### PR TITLE
Avoid set-coding-priority for Emacs 28

### DIFF
--- a/mew-env.el
+++ b/mew-env.el
@@ -99,7 +99,8 @@ requires PTY.")
 
 (with-no-warnings
   (defun mew-set-coding-priority (pri)
-    (set-coding-priority pri)))
+    (apply 'set-coding-system-priority
+	   (mapcar (lambda (x) (symbol-value x)) pri))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
On a recent Emacs 28.0.50, C-c C-l (mew-summary-convert-local-cs) fails
with the error: (void-function set-coding-priority), because the
set-coding-priority function obsolete since Emacs 23.1 have been removed.
cf. http://git.savannah.gnu.org/cgit/emacs.git/commit/?id=874ba85363e90a54f976af542e9b3f4c662e317e
