### PR TITLE
Improve gitlog2mewchanges to remove item marks

### DIFF
--- a/gitlog2mewchanges
+++ b/gitlog2mewchanges
@@ -43,8 +43,8 @@ sub print_entry {
 
     $comment =~ s/\n([ \t]*\n.*)+/\n/g;
     $comment =~ s/\n+$//;
+    $comment =~ s/^[-*] //mg;
     $comment =~ s/\n/\n  /g;
-    $comment =~ s/^[-*] //;
     $comment =~ s/\.(  |\n).*/./s;
     print "$comment\n";
 


### PR DESCRIPTION
This commit removes the leading "- "s from the commit log of
<https://github.com/hrs-allbsd/Mew/commit/e2373bb0d39ba5c97992456d84443835e21ba6f0>.
