### PR TITLE
Check emacs-build-number and emacs-version for mew-x-mailer

### DIFF
--- a/mew-const.el
+++ b/mew-const.el
@@ -161,7 +161,7 @@
   (+ (length [key beg end pri]) (length mew-mime-fields)))
 
 (defconst mew-x-mailer
-  (format "%s on Emacs %d.%d" mew-version emacs-major-version emacs-minor-version)
+  (format "%s on Emacs %s" mew-version emacs-version)
   "*A value inserted into X-Mailer: field in Draft mode if *non-nil*.")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;


### PR DESCRIPTION
Currently, mew-x-mailer includes "Emacs 27.1", "Emacs 28.0" for
Emacs 27.1.90, 28.0.50.

Expected results are "Emacs 27.1.90", "Emacs 28.0.50".

Note that emacs-version no longer includes the build number since
Emacs 26, so emacs-build-number should be checked for Emacs 24 and 25
to use emacs-version.

cf. https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS.26#n300

> ** The variable 'emacs-version' no longer includes the build number.
> This is now stored separately in a new variable, 'emacs-build-number'.
