### PR TITLE
add support ssl connection via proxy.

### DIFF
--- a/elisp/mew-config.el
+++ b/elisp/mew-config.el
@@ -160,6 +160,12 @@
 (defun mew-ssl-verify-level (&optional case)
   (mew-cfent-value case "ssl-verify-level" mew-ssl-verify-level))
 
+(defun mew-ssl-proxy-server (&optional case)
+  (mew-cfent-value case "ssl-proxy-server" mew-ssl-proxy-server))
+
+(defun mew-ssl-proxy-port (&optional case)
+  (mew-cfent-value case "ssl-proxy-port" mew-ssl-proxy-port))
+
 ;;
 
 (defun mew-smtp-server (&optional case)

--- a/elisp/mew-ssl.el
+++ b/elisp/mew-ssl.el
@@ -47,6 +47,9 @@ insert no extra text.")
 
 (defconst mew-ssl-process-exec-cnt 3)
 
+(defvar mew-ssl-proxy-server nil)
+(defvar mew-ssl-proxy-port nil)
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Magic words
@@ -130,8 +133,13 @@ insert no extra text.")
 	    (insert (mew-prog-ssl-arg case)))
 	(insert (format "[%d]\n" localport))
 	(insert (format "accept=%s:%d\n" mew-ssl-localhost localport))
-	(insert (format "connect=%s:%d\n" server remoteport))
-	(if tls (insert (format "protocol=%s\n" tls)))
+	(if mew-ssl-proxy-server
+	    (insert
+	     (format "connect=%s:%s\nprotocol=connect\nprotocolHost=%s:%d\n"
+		     mew-ssl-proxy-server mew-ssl-proxy-port
+		     server remoteport))
+	  (insert (format "connect=%s:%d\n" server remoteport))
+	  (if tls (insert (format "protocol=%s\n" tls))))
 	(mew-frwlet mew-cs-dummy mew-cs-text-for-write
 	  ;; NEVER use call-process-region for privacy reasons
 	  (write-region (point-min) (point-max) file nil 'no-msg))

--- a/elisp/mew-ssl.el
+++ b/elisp/mew-ssl.el
@@ -133,10 +133,10 @@ insert no extra text.")
 	    (insert (mew-prog-ssl-arg case)))
 	(insert (format "[%d]\n" localport))
 	(insert (format "accept=%s:%d\n" mew-ssl-localhost localport))
-	(if mew-ssl-proxy-server
+	(if (mew-ssl-proxy-server case)
 	    (insert
 	     (format "connect=%s:%s\nprotocol=connect\nprotocolHost=%s:%d\n"
-		     mew-ssl-proxy-server mew-ssl-proxy-port
+		     (mew-ssl-proxy-server case) (mew-ssl-proxy-port case)
 		     server remoteport))
 	  (insert (format "connect=%s:%d\n" server remoteport))
 	  (if tls (insert (format "protocol=%s\n" tls))))


### PR DESCRIPTION
This PR adds proxy setting to stunnel so that SSL/TLS connection uses http proxy.

setq two variables for proxy, like the followings,

(setq mew-ssl-proxy-server "proxy-server.example.com") 
(setq mew-ssl-proxy-port "8080")

the patch was also reported on mew-ja ML, past, 

---
Subject: [mew-ja] proxyを経由したSSL接続対応
Date: Sat, 13 Jun 2020 23:46:14 +0900 (JST)
