### PR TITLE
Fix make install-elisp fails with empty elispdir

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -71,7 +71,7 @@ elisp::
 	cd elisp; $(MAKE) EMACS=$(EMACS)
 
 install-elisp:
-	cd elisp; $(MAKE) install EMACS=$(EMACS) DESTDIR=$(DESTDIR)
+	cd elisp; $(MAKE) install EMACS=$(EMACS) elispdir=$(elispdir) DESTDIR=$(DESTDIR)
 
 ################################################################
 

--- a/elisp/Makefile
+++ b/elisp/Makefile
@@ -5,6 +5,10 @@
 ### Created: Nov 18, 1994
 ### Revised: Feb 10, 2023
 
+EMACS = emacs
+prefix = /usr/local
+elispdir = $(prefix)/share/emacs/site-lisp/mew
+
 ################################################################
 ##
 ## DO NOT EDIT THE FOLLOWINGS


### PR DESCRIPTION
cf. https://groups.google.com/g/mew-ja/c/LBVxG5mo-1I/m/HWURPTpSBAAJ

Also, `cd elisp && make` fails to byte-compile because of empty `EMACS`.
`EMACS` and `elispdir` should have the default value in elisp/Makefile
if `cd elisp && make` is allowed.

Instead, you may integrate elisp/Makefile into Makefile, like install-etc.
