### PR TITLE
Use configured file names as relative paths from mew-home.

### DIFF
--- a/elisp/mew-draft.el
+++ b/elisp/mew-draft.el
@@ -290,10 +290,10 @@ the Body: field."
 
 (defun mew-draft-header-insert-xface ()
   (if (and mew-x-face-file
-	   (file-exists-p (expand-file-name mew-x-face-file)))
+	   (file-exists-p (expand-file-name mew-x-face-file mew-home)))
       (let (xface)
 	(with-temp-buffer
-	  (mew-insert-file-contents (expand-file-name mew-x-face-file))
+	  (mew-insert-file-contents (expand-file-name mew-x-face-file mew-home))
 	  (setq xface (mew-buffer-substring (point-min)
 					    (max (buffer-size) 1))))
 	(mew-draft-header-insert mew-x-face: xface))))
@@ -686,7 +686,7 @@ you can set the case."
       (setq case (mew-input-case (mew-tinfo-get-case) "Signature")))
      (t
       (setq case (mew-tinfo-get-case))))
-    (setq sigfile (expand-file-name (mew-signature-file case)))
+    (setq sigfile (expand-file-name (mew-signature-file case) mew-home))
     (if (not (file-exists-p sigfile))
 	(message "No signature file %s" sigfile)
       (if (and (mew-attach-p) mew-signature-as-lastpart)


### PR DESCRIPTION
I had configured mew-signature-file with a relative path for long time.

    (setq mew-signature-file ".signature")

I supposed that it means "relative from mew-home" then it means ~/.signature.  But it doesn't work on 6.9.  I seems try to open .signature related to the working directory of the running process.

The behavior changed by commit 59e9ad9ee3478040f0f5b73781deebe3079a0f38.  I'd like to revert the previous behavior.
