### PR TITLE
Update minimum version requirement of stunnel

### DIFF
--- a/info/mew.texi
+++ b/info/mew.texi
@@ -12554,13 +12554,13 @@ command line.
 
 @ifset ja
 SSL を使うには、認証局方式の信用モデルを理解している必要があります。現
-在、Mew は SSL のために "stunnel" バージョン 3、4、5 をサポートしていま
+在、Mew は SSL のために "stunnel" バージョン 5.15以降 をサポートしていま
 す。
 @end ifset
 @ifset en
 Before you use SSL, you should understand the trust model of
 certificate authorities (CA). Currently, Mew supports "stunnel" version
-3, 4 and 5 for SSL.
+5.15 or later for SSL.
 @end ifset
 
 @ifset ja


### PR DESCRIPTION
According to the result of discussuion at mew-ja ML, update minimum version requirement of stunnel from 3 to 5.15.

Changes:
* Check if supported version of stunnel is installed in `mew-open-ssl-stream`.
* Remove codes for versions that aren't supported any more.
  + Remove description about case of stunnel 3.x from documentation string of `mew-prog-ssl-arg`.
  + Remove case of stunnel 3.x from `mew-ssl-options`.
  + Since `checkHost` option is always available now,
    - Remove check if this option is available from `mew-ssl-setup`.
    - Remove check the value of `mew-ssl-checkhost` from `mew-ssl-options`.
    - Remove variable definition of `mew-ssl-checkhost`.
  + Remove version check related to LIBWRAP feature from `mew-ssl-options` as it is alway true now.
  + Remove version check related to mew-ssl-set-file from `mew-open-ssl-stream` as it is alway true now.
* Update info files.