### PR TITLE
Enable IPv6 support of stunnel by default

### DIFF
--- a/elisp/mew-ssl.el
+++ b/elisp/mew-ssl.el
@@ -137,8 +137,7 @@ no extra text.")
 (defconst mew-tls-nntp "nntp")
 (defconst mew-tls-imap "imap") ;; xxx stunnel does not support this.
 
-;; stunnel does not support IPv6, sigh
-(defconst mew-ssl-localhost "127.0.0.1")
+(defconst mew-ssl-localhost "localhost")
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;


### PR DESCRIPTION
There is following comment before the variable definition of `mew-ssl-localhost`.

```elisp
;; stunnel does not support IPv6, sigh
```

However, it seems recent version of stunnel works fine with IPv6. So enable IPv6 support by default. Also remove above comment as it doesn't make sence any more.