### PR TITLE
placing mew-mode-line-format in the end of mode-line-format

### DIFF
--- a/elisp/mew-summary.el
+++ b/elisp/mew-summary.el
@@ -261,8 +261,6 @@ and return (beg . end)."
 (defvar mew-mode-line-target "%p")
 (defvar mew-mode-line-format
   `(""
-    (mew-summary-buffer-left-msgs mew-summary-buffer-left-msgs "L%l")
-    (mew-summary-buffer-raw "*")
     (mew-summary-buffer-secure-process ,mew-secure-format2)))
 
 (defvar mew-mode-line-process
@@ -272,20 +270,11 @@ and return (beg . end)."
 (defun mew-summary-setup-mode-line ()
   (let ((tgt mew-mode-line-target)
 	target prev pos)
-    (if (boundp 'mode-line-position)
-	(progn
-	  (make-local-variable 'mode-line-position) ;; Emacs 21.3.50
-	  (setq mode-line-position
-		(copy-sequence (default-value 'mode-line-position)))
-	  (setq prev mode-line-position))
-      (setq mode-line-format (copy-sequence (default-value 'mode-line-format)))
-      (setq prev mode-line-format))
-    (setq target (or (rassoc (list tgt) prev) ;; Emacs 21.3.50
-		     (rassoc tgt prev)
-		     (car (member tgt prev))))
-    (when target
-      (setq pos (- (length prev) (length (member target prev))))
-      (setcar (nthcdr pos prev) mew-mode-line-format))
+    (when (boundp 'mode-line-format)
+      (make-local-variable 'mode-line-format)
+      (setq mode-line-format
+	    (copy-sequence (default-value 'mode-line-format)))
+      (nconc mode-line-format mew-mode-line-format))
     (when (boundp 'line-number-mode)
       (make-local-variable 'line-number-mode)
       (setq line-number-mode nil))

--- a/elisp/mew-summary.el
+++ b/elisp/mew-summary.el
@@ -258,7 +258,6 @@ and return (beg . end)."
 ;;; Modeline
 ;;;
 
-(defvar mew-mode-line-target "%p")
 (defvar mew-mode-line-format
   `(""
     (mew-summary-buffer-secure-process ,mew-secure-format2)))

--- a/elisp/mew-summary.el
+++ b/elisp/mew-summary.el
@@ -268,19 +268,17 @@ and return (beg . end)."
     (mew-summary-buffer-process mew-summary-buffer-process-status)))
 
 (defun mew-summary-setup-mode-line ()
-  (let ((tgt mew-mode-line-target)
-	target prev pos)
-    (when (boundp 'mode-line-format)
-      (make-local-variable 'mode-line-format)
-      (setq mode-line-format
-	    (copy-sequence (default-value 'mode-line-format)))
-      (nconc mode-line-format mew-mode-line-format))
-    (when (boundp 'line-number-mode)
-      (make-local-variable 'line-number-mode)
-      (setq line-number-mode nil))
-    (or (assq 'mew-summary-buffer-process mode-line-process)
-	(setq mode-line-process
-	      (append mew-mode-line-process mode-line-process)))))
+  (when (boundp 'mode-line-format)
+    (make-local-variable 'mode-line-format)
+    (setq mode-line-format
+	  (copy-sequence (default-value 'mode-line-format)))
+    (nconc mode-line-format mew-mode-line-format))
+  (when (boundp 'line-number-mode)
+    (make-local-variable 'line-number-mode)
+    (setq line-number-mode nil))
+  (or (assq 'mew-summary-buffer-process mode-line-process)
+      (setq mode-line-process
+	    (append mew-mode-line-process mode-line-process))))
 
 (defun mew-summary-reset-mode-line ()
   (setq mew-summary-buffer-left-msgs nil))


### PR DESCRIPTION
The lock icon has not been displayed since Emacs 26.1.
This is because `"%p"` is replaced with `mode-line-percent-position` in `mode-line-position`.

First, we supports Emacs 26.1 or later. So, let's remove the code assuming `"%p"`.
Second, to make things simple, let's put `mew-mode-line-format` in the end of `mode-line-format`.