### PR TITLE
Fix stopping during greeting on some POPs servers

### DIFF
--- a/elisp/mew-imap.el
+++ b/elisp/mew-imap.el
@@ -1462,10 +1462,13 @@
 	(set-process-buffer process buf)
 	;;
 	(when sslnp
-	  ;; GnuTLS requires a client-initiated command after the
-	  ;; session is established or upgraded to use TLS because
-	  ;; no additional greeting from the server.
-	  (mew-imap-filter process "* OK\n"))
+	  ;; GnuTLS receives IMAP greeting in its internals
+	  ;; and passes it as a return value.
+	  ;; We store the value in the variable mew--gnutls-imap-greeting
+	  ;; and pass it to the filter to process the greeting.
+	  (mew-imap-filter process
+			  (string-replace "\r\n" "\n"
+					  mew--gnutls-imap-greeting)))
 	))))
 
 (defun mew-imap-exec-recover (bnm)

--- a/elisp/mew-imap.el
+++ b/elisp/mew-imap.el
@@ -1465,8 +1465,7 @@
 	  ;; GnuTLS requires a client-initiated command after the
 	  ;; session is established or upgraded to use TLS because
 	  ;; no additional greeting from the server.
-	  (mew-imap-set-status pnm "capability")
-	  (mew-imap-command-capability process pnm))
+	  (mew-imap-filter process "* OK\n"))
 	))))
 
 (defun mew-imap-exec-recover (bnm)

--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -774,7 +774,7 @@
 	  ;; GnuTLS requires a client-initiated command after the
 	  ;; session is established or upgraded to use TLS because
 	  ;; no additional greeting from the server.
-	  (mew-pop-command-capa process pnm))
+	  (mew-pop-filter process "+OK\n"))
 	))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -771,10 +771,13 @@
 	(set-process-filter process 'mew-pop-filter)
 	(set-process-buffer process buf)
 	(when sslnp
-	  ;; GnuTLS requires a client-initiated command after the
-	  ;; session is established or upgraded to use TLS because
-	  ;; no additional greeting from the server.
-	  (mew-pop-filter process "+OK\n"))
+	  ;; GnuTLS receives POP greeting in its internals
+	  ;; and passes it as a return value.
+	  ;; We store the value in the variable mew--gnutls-pop-greeting
+	  ;; and pass it to the filter to process the greeting.
+	  (mew-pop-filter process
+			  (string-replace "\r\n" "\n"
+					  mew--gnutls-pop-greeting)))
 	))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/elisp/mew-smtp.el
+++ b/elisp/mew-smtp.el
@@ -586,6 +586,7 @@
 		;; When a validation error occurs, (car pro) will be nil.
 		;;
 		(let ((plainp (eq 'plain (plist-get (cdr pro) :type)))
+		      (greeting (plist-get (cdr pro) :greeting))
 		      (openp  (and (car pro)
 				   (eq 'open (process-status (car pro)))))
 		      ;; Falling back to a plain connection is allowed
@@ -608,7 +609,12 @@
 		   (t
 		    (setq pro (list
 			       (car pro)
-			       :error nil)))))))))
+			       :error nil))
+		    (cond
+		     ((eq proto 'pop)
+		      (setq mew--gnutls-pop-greeting greeting))
+		     ((eq proto 'imap)
+		      (setq mew--gnutls-imap-greeting greeting))))))))))
 	 (t
 	  (with-temp-message status-msg
 	    (let ((params (list :name name :buffer buf


### PR DESCRIPTION
Some POPs servers (e.g. secure.plala.or.jp:995) split CAPA responses into multiple packets.
Mew stopped greeting unless the CAPA response was a single packet. This commit fixes to allow for multiple packets of CAPA responses in greetings.