### PR TITLE
Fix cases where summary mode marks are not saved to the local cache in IMAP

### DIFF
--- a/elisp/mew-imap.el
+++ b/elisp/mew-imap.el
@@ -1616,7 +1616,8 @@
 	 (file (mew-expand-file bnm mew-imap-msgid-file))
 	 (buf (process-buffer process))
 	 (virtual-info (mew-imap-get-virtual-info pnm))
-	 (disp-info (mew-imap-get-disp-info pnm)))
+	 (disp-info (mew-imap-get-disp-info pnm))
+	 (sinfo-mark-hist (mew-sinfo-get-mark-hist)))
     (save-excursion
       (mew-imap-debug "IMAP SENTINEL" event)
       (set-process-buffer process nil)
@@ -1683,7 +1684,9 @@
 	  (mew-net-uidl-db-set (mew-imap-passtag pnm) uidl)
 	  (cond
 	   ((= rttl 0)
-	    (mew-imap-message pnm "No new messages"))
+	    (mew-imap-message pnm "No new messages")
+	    (when sinfo-mark-hist
+	      (mew-summary-folder-cache-save)))
 	   ((= rttl 1)
 	    (mew-imap-message pnm "1 message retrieved")
 	    (mew-summary-folder-cache-save))
@@ -1693,7 +1696,9 @@
 	 ((eq directive 'get)
 	  (cond
 	   ((= rttl 0)
-	    (mew-imap-message pnm "The message does not exist"))
+	    (mew-imap-message pnm "The message does not exist")
+	    (when sinfo-mark-hist
+	      (mew-summary-folder-cache-save)))
 	   ((= rttl 1)
 	    (mew-imap-message pnm "1 message retrieved")
 	    (mew-summary-folder-cache-save))
@@ -1704,7 +1709,9 @@
 	  (mew-biff-clear)
 	  (cond
 	   ((or (= rttl 0) (null msgid))
-	    (mew-imap-message pnm "No new messages"))
+	    (mew-imap-message pnm "No new messages")
+	    (when sinfo-mark-hist
+	      (mew-summary-folder-cache-save)))
 	   ((= rttl 1)
 	    (mew-imap-message pnm "1 message retrieved")
 	    (mew-lisp-save file msgid nil 'unlimit)
@@ -1720,7 +1727,8 @@
 		  (mew-inherit-offline t))
 	      (mew-mark-exec-refile bnm movs)))
 	  (when (or kils movs)
-	    (mew-mark-kill-invisible)
+	    (mew-mark-kill-invisible))
+	  (when (or kils movs sinfo-mark-hist)
 	    (mew-summary-folder-cache-save))
 	  (cond
 	   ((= rttl 1)


### PR DESCRIPTION
If there were no new messages in the IMAP scan, etc., the summary mode marks were not saved to the local cache.

This commit fixes it.