### PR TITLE
Add mew-oauth2.{el,elc} to {SRCS,OBJS} in elisp/Makefile

### DIFF
--- a/elisp/Makefile
+++ b/elisp/Makefile
@@ -28,12 +28,12 @@ OBJS =	mew-addrbook.elc	mew-attach.elc		mew-auth.elc	\
 	mew-message.elc		mew-mime.elc		mew-minibuf.elc	\
 	mew-mule.elc		mew-mule3.elc	\
 	mew-net.elc		mew-nntp.elc		mew-nntp2.elc	\
-	mew-pgp.elc		mew-pick.elc		mew-pop.elc	\
-	mew-refile.elc		mew-scan.elc		mew-smime.elc	\
-	mew-search.elc		mew-smtp.elc		mew-sort.elc	\
-	mew-ssh.elc		mew-ssl.elc		mew-passwd.elc	\
-	mew-summary.elc		mew-summary2.elc	mew-summary3.elc \
-	mew-summary4.elc	mew-syntax.elc		\
+	mew-oauth2.elc		mew-pgp.elc		mew-pick.elc	\
+	mew-pop.elc		mew-refile.elc		mew-scan.elc	\
+	mew-smime.elc		mew-search.elc		mew-smtp.elc	\
+	mew-sort.elc		mew-ssh.elc		mew-ssl.elc	\
+	mew-passwd.elc		mew-summary.elc		mew-summary2.elc \
+	mew-summary3.elc 	mew-summary4.elc	mew-syntax.elc	\
 	mew-thread.elc		mew-unix.elc		\
 	mew-vars.elc		mew-vars2.elc		mew-vars3.elc	\
 	mew-varsx.elc		mew-virtual.elc		\
@@ -54,12 +54,12 @@ SRCS =	mew-addrbook.el	mew-attach.el	mew-auth.el	\
 	mew-message.el	mew-mime.el	mew-minibuf.el	\
 	mew-mule.el	mew-mule3.el	\
 	mew-net.el	mew-nntp.el	mew-nntp2.el	\
-	mew-pgp.el	mew-pick.el	mew-pop.el	\
-	mew-refile.el	mew-scan.el	mew-smime.el	\
-	mew-search.el	mew-smtp.el	mew-sort.el	\
-	mew-ssh.el	mew-ssl.el	mew-passwd.el	\
-	mew-summary.el	mew-summary2.el	mew-summary3.el	\
-	mew-summary4.el	mew-syntax.el	\
+	mew-oauth2.el	mew-pgp.el	mew-pick.el	\
+	mew-pop.el	mew-refile.el	mew-scan.el	\
+	mew-smime.el	mew-search.el	mew-smtp.el	\
+	mew-sort.el	mew-ssh.el	mew-ssl.el	\
+	mew-passwd.el	mew-summary.el	mew-summary2.el	\
+	mew-summary3.el	mew-summary4.el	mew-syntax.el	\
 	mew-thread.el	mew-unix.el	\
 	mew-vars.el	mew-vars2.el	mew-vars3.el	\
 	mew-varsx.el	mew-virtual.el	\


### PR DESCRIPTION
It fixes problem that `make install` doesn't install them.