### PR TITLE
Support mew-config-alist to use XOAUTH2 for each servers

### DIFF
--- a/elisp/mew-config.el
+++ b/elisp/mew-config.el
@@ -516,6 +516,30 @@
 (defun mew-use-format-flowed (&optional case)
   (mew-cfent-value case "use-format-flowed" mew-use-format-flowed))
 
+;;
+
+(defun mew-oauth2-client-id (&optional case)
+  (mew-cfent-value case "oauth2-client-id" mew-oauth2-client-id))
+
+(defun mew-oauth2-client-secret (&optional case)
+  (mew-cfent-value case "oauth2-client-secret" mew-oauth2-client-secret))
+
+(defun mew-oauth2-redirect-url (&optional case)
+  (mew-cfent-value case "oauth2-redirect-url" mew-oauth2-redirect-url))
+
+(defun mew-oauth2-redirect-port (&optional case)
+  (mew-cfent-value case "oauth2-redirect-port" mew-oauth2-redirect-port))
+
+(defun mew-oauth2-auth-url (&optional case)
+  (mew-cfent-value case "oauth2-auth-url" mew-oauth2-auth-url))
+
+(defun mew-oauth2-token-url (&optional case)
+  (mew-cfent-value case "oauth2-token-url" mew-oauth2-token-url))
+
+(defun mew-oauth2-resource-url (&optional case)
+  (mew-cfent-value case "oauth2-resource-url" mew-oauth2-resource-url))
+
+
 ;;;
 ;;; Setting case
 ;;;

--- a/elisp/mew-imap.el
+++ b/elisp/mew-imap.el
@@ -1017,7 +1017,7 @@
 (defun mew-imap-command-auth-xoauth2 (pro pnm)
   (let* ((user (mew-imap-get-user pnm))
 	 (tag (mew-imap-passtag pnm))
-         (auth-string (mew-xoauth2-auth-string user tag)))
+         (auth-string (mew-xoauth2-auth-string user tag (mew-imap-get-case pnm))))
     (mew-imap-process-send-string pro pnm (format "AUTHENTICATE XOAUTH2 %s" auth-string))
     (mew-imap-set-status pnm "auth-xoauth2")))
 

--- a/elisp/mew-imap2.el
+++ b/elisp/mew-imap2.el
@@ -286,7 +286,7 @@
 (defun mew-imap2-command-auth-xoauth2 (pro pnm)
   (let* ((user (mew-imap2-get-user pnm))
 	 (tag (mew-imap2-passtag pnm))
-         (auth-string (mew-xoauth2-auth-string user tag)))
+         (auth-string (mew-xoauth2-auth-string user tag (mew-imap-get-case pnm))))
     ;; XXX: need to reset satus if token is nil.
     (mew-imap2-process-send-string pro pnm (format "AUTHENTICATE XOAUTH2 %s" auth-string))
     (mew-imap2-set-status pnm "auth-xoauth2")))

--- a/elisp/mew-oauth2.el
+++ b/elisp/mew-oauth2.el
@@ -12,6 +12,14 @@
 ;;;
 ;;; Variables
 ;;;
+(defvar mew-oauth2-info-list
+  '("code"
+    "client-id" "client-secret"
+    "redirect-url" "redirect-port"
+    "auth-url" "token-url" "resource-url"
+    ))
+
+(mew-info-defun "mew-oauth2-" mew-oauth2-info-list)
 
 (defvar mew-oauth2-client-id nil)
 
@@ -33,6 +41,17 @@
 
 (defvar mew-oauth2-resource-url "https://mail.google.com/"
   "URL used to request access to Mail Resources.")
+
+(defun mew-oauth2-debug (label string)
+  (when (mew-debug 'oauth2)
+    (with-current-buffer (get-buffer-create mew-buffer-debug)
+      (goto-char (point-max))
+      (let ((start (point)))
+	(insert (format "\n<%s>\n%s\n" label string))
+	(goto-char start)
+	(mew-crlf-to-lf))
+      (goto-char (point-max)))))
+
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
@@ -68,7 +87,8 @@ It serves http://localhost:PORT"
   )
 
 (defun mew-oauth2-redirect-handler-filter (proc string)
-  (if (string-match "^GET .*[?&]code=\\([^&]+\\)" string)
+  (mew-oauth2-debug "OAUTH2:" string)
+  (if (string-match "^GET .*[?&]code=\\([^& ]+\\)" string)
       (let ((code (match-string 1 string)))
         (process-send-string
          proc
@@ -76,7 +96,7 @@ It serves http://localhost:PORT"
                  "Content-Type: text/plain\r\n"
                  "\r\n"
                  "Mew gets the following authorization code:\n"
-		 code "\n"))
+		 code "***\n"))
 	(setq mew-oauth2-code code)
 	(delete-process proc))))
 
@@ -86,6 +106,7 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-get-auth-code (url client-id resource-url redirect-url challenge port)
+  (mew-oauth2-debug "OAUTH2:" (concat "get-auth-code" url client-id))
   (let ((url-params
 	 (concat
 	  url
@@ -113,6 +134,7 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-get-access-token (url client-id client-secret redirect-url code verifier)
+  (mew-oauth2-debug "OAUTH2:" (concat "get-accesss-token" url client-id))
   (let ((params (concat 
 		 "grant_type=authorization_code"
 		 "&code=" code
@@ -131,6 +153,7 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-refresh-access-token (url client-id client-secret refresh-token)
+  (mew-oauth2-debug "OAUTH2:" (concat "refresh-accesss-token" url client-id))
   (let ((params (concat 
 		 "grant_type=refresh_token"
 		 "&client_id=" client-id
@@ -158,16 +181,17 @@ It serves http://localhost:PORT"
           "NO") ;; XXX: Anyway NO?
       "OK"))) ;; XXX: Maybe OK if not JSON.
 
-(defun mew-xoauth2-auth-string (user tag)
+(defun mew-xoauth2-auth-string (user tag case)
   (mew-passwd-setup-master)
   (let* ((tk (mew-passwd-get-passwd tag))
          (token (if (hash-table-p tk) tk (make-hash-table)))
-         (access-token (mew-xoauth2-get-access-token token)))
+         (access-token (mew-xoauth2-get-access-token token case)))
     (mew-passwd-set-passwd tag token)
     ;; base64(user=user@example.com^Aauth=Bearer ya29vF9dft4...^A^A)
     (base64-encode-string (format "user=%s\1auth=Bearer %s\1\1" user access-token) t)))
 
-(defun mew-xoauth2-get-access-token (token)
+(defun mew-xoauth2-get-access-token (token case)
+  (mew-oauth2-debug "OAUTH2:" (concat "get-access-toekn" case))
   (let* ((expire (gethash :expire token))
 	 (access-token (gethash :access_token token))
 	 (refresh-token (gethash :refresh_token token)))
@@ -176,9 +200,9 @@ It serves http://localhost:PORT"
       access-token)
      (refresh-token
       (let* ((json (mew-oauth2-refresh-access-token
-		    mew-oauth2-token-url
-		    mew-oauth2-client-id
-		    mew-oauth2-client-secret
+		    (mew-oauth2-token-url case)
+		    (mew-oauth2-client-id case)
+		    (mew-oauth2-client-secret case)
 		    refresh-token))
 	     (expires-in (gethash "expires_in" json))
 	     (refresh-token (gethash "refresh_token" json)))
@@ -192,17 +216,17 @@ It serves http://localhost:PORT"
       (let* ((verifier (mew-oauth2-pkce-code-verifier))
 	     (challenge (mew-oauth2-pkce-code-challenge verifier))
 	     (auth-code (mew-oauth2-get-auth-code
-			 mew-oauth2-auth-url
-			 mew-oauth2-client-id
-			 mew-oauth2-resource-url
-			 mew-oauth2-redirect-url
+			 (mew-oauth2-auth-url case)
+			 (mew-oauth2-client-id case)
+			 (mew-oauth2-resource-url case)
+			 (mew-oauth2-redirect-url case)
 			 challenge
-			 8080))
+			 (mew-oauth2-redirect-port case)))
 	     (json (mew-oauth2-get-access-token 
-		    mew-oauth2-token-url
-		    mew-oauth2-client-id
-		    mew-oauth2-client-secret
-		    mew-oauth2-redirect-url
+		    (mew-oauth2-token-url case)
+		    (mew-oauth2-client-id case)
+		    (mew-oauth2-client-secret case)
+		    (mew-oauth2-redirect-url case)
 		    auth-code
 		    verifier))
 	     (expires-in (gethash "expires_in" json)))

--- a/elisp/mew-oauth2.el
+++ b/elisp/mew-oauth2.el
@@ -87,7 +87,6 @@ It serves http://localhost:PORT"
   )
 
 (defun mew-oauth2-redirect-handler-filter (proc string)
-  (mew-oauth2-debug "OAUTH2:" string)
   (if (string-match "^GET .*[?&]code=\\([^& ]+\\)" string)
       (let ((code (match-string 1 string)))
         (process-send-string
@@ -96,7 +95,7 @@ It serves http://localhost:PORT"
                  "Content-Type: text/plain\r\n"
                  "\r\n"
                  "Mew gets the following authorization code:\n"
-		 code "***\n"))
+		 code "\n"))
 	(setq mew-oauth2-code code)
 	(delete-process proc))))
 
@@ -106,7 +105,6 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-get-auth-code (url client-id resource-url redirect-url challenge port)
-  (mew-oauth2-debug "OAUTH2:" (concat "get-auth-code" url client-id))
   (let ((url-params
 	 (concat
 	  url
@@ -134,7 +132,6 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-get-access-token (url client-id client-secret redirect-url code verifier)
-  (mew-oauth2-debug "OAUTH2:" (concat "get-accesss-token" url client-id))
   (let ((params (concat 
 		 "grant_type=authorization_code"
 		 "&code=" code
@@ -153,7 +150,6 @@ It serves http://localhost:PORT"
 ;;;
 
 (defun mew-oauth2-refresh-access-token (url client-id client-secret refresh-token)
-  (mew-oauth2-debug "OAUTH2:" (concat "refresh-accesss-token" url client-id))
   (let ((params (concat 
 		 "grant_type=refresh_token"
 		 "&client_id=" client-id
@@ -191,7 +187,6 @@ It serves http://localhost:PORT"
     (base64-encode-string (format "user=%s\1auth=Bearer %s\1\1" user access-token) t)))
 
 (defun mew-xoauth2-get-access-token (token case)
-  (mew-oauth2-debug "OAUTH2:" (concat "get-access-toekn" case))
   (let* ((expire (gethash :expire token))
 	 (access-token (gethash :access_token token))
 	 (refresh-token (gethash :refresh_token token)))

--- a/elisp/mew-passwd.el
+++ b/elisp/mew-passwd.el
@@ -230,7 +230,7 @@
   (if (and key (or mew-use-cached-passwd mew-use-master-passwd))
       (progn
 	(mew-passwd-setup-master)
-	(if (mew-passwd-get-passwd key)
+	(if (stringp (mew-passwd-get-passwd key))
 	    (progn
 	      (mew-timing)
 	      (if mew-passwd-reset-timer (mew-passwd-set-counter key 0))

--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -515,7 +515,7 @@
 (defun mew-pop-command-auth-xoauth2 (pro pnm)
   (let* ((user (mew-pop-get-user pnm))
 	 (tag (mew-pop-passtag pnm))
-         (auth-string (mew-xoauth2-auth-string user tag)))
+         (auth-string (mew-xoauth2-auth-string user tag (mew-pop-get-case pnm))))
     (mew-pop-process-send-string pro "AUTH XOAUTH2 %s" auth-string)
     (mew-smtp-set-status pnm "auth-xoauth2")))
 

--- a/elisp/mew-smtp.el
+++ b/elisp/mew-smtp.el
@@ -321,7 +321,7 @@
 (defun mew-smtp-command-auth-xoauth2 (pro pnm)
   (let* ((user (mew-smtp-get-auth-user pnm))
 	 (tag (mew-smtp-passtag pnm))
-         (auth-string (mew-xoauth2-auth-string user tag)))
+         (auth-string (mew-xoauth2-auth-string user tag (mew-smtp-get-case pnm))))
     (mew-smtp-process-send-string pro "AUTH XOAUTH2 %s" auth-string)
     (mew-smtp-set-status pnm "auth-xoauth2")))
 


### PR DESCRIPTION
#172
mew-config-alistでXOAUTH2関連の設定をできるようにしてみました。

https://qiita.com/waiseiningenchokon/items/fd0ce39ae0f08c73e273
を参考に、Microsoft Entra ID (旧 Azure Active Directory)にアプリを登録しclient-idを取得することで、以下のような設定で個人用の(組織用でなく)outlook.comが使えています。(gmailと並行して)

https://www.rworks.jp/system/system-column/sys-practice/27806/
にある通り、client-secretはnilにする必要があるようです。

あまり望ましくないようですが、client-id, client-secretもmew-config-alistに入れるようにしています。

(setq mew-config-alist
      '(("xoutlook"
	 ("oauth2-client-id" . "your appropriate value")
	 ("oauth2-client-secret" . nil)
	 ("oauth2-auth-url" . "https://login.microsoftonline.com/consumers/oauth2/v2.0/authorize")
	 ("oauth2-token-url" . "https://login.microsoftonline.com/consumers/oauth2/v2.0/token")
         ("oauth2-resource-url" . "openid offline_access https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send")	 
	 ("oauth2-redirect-url" .  "http://localhost:8080")
	 ("oauth2-redirect-port" . 8080)
	 ("imap-auth-list" . ("XOAUTH2"))
	 ("smtp-auth-list" . ("XOAUTH2"))
         ...
