### PR TITLE
Support "BIMI-Indicator:" Header

### DIFF
--- a/elisp/mew-const.el
+++ b/elisp/mew-const.el
@@ -72,6 +72,7 @@
 (defconst mew-x-mailer:    "X-Mailer:")
 (defconst mew-x-face:      "X-Face:")
 (defconst mew-face:        "Face:")
+(defconst mew-bimi-indicator: "BIMI-Indicator:")
 (defconst mew-x-mew:       "X-Mew:")
 (defconst mew-x-mew-uidl:  "X-Mew-Uidl:")
 (defconst mew-x-mew-ref:   "X-Mew-Ref:")

--- a/elisp/mew-decode.el
+++ b/elisp/mew-decode.el
@@ -200,6 +200,7 @@ This commands toggles visibility of these lines."
 	 (mew-decode-syntax-insert-privacy)
 	 (mew-decode-syntax-insert-warning)
 	 (save-excursion (mew-highlight-x-face (point-min) (point-max)))
+	 (save-excursion (mew-highlight-bimi (point-min) (point-max)))
 	 (setq vispos (if (get-text-property (point-min) 'mew-visible)
 			  (point-min)
 			(or (next-single-property-change (point-min) 'mew-visible)

--- a/elisp/mew-gemacs.el
+++ b/elisp/mew-gemacs.el
@@ -407,6 +407,19 @@ with fitting to frame size"
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; BIMI
+;;;
+
+(defun mew-bimi-display (bimi)
+  (save-excursion
+    (goto-char (point-min))
+    (let ((regex2 (concat "^\\(" mew-from: "\\).*")))
+      (when (re-search-forward regex2 nil t)
+	(goto-char (match-end 1))
+	(insert-image bimi)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; SSL/SSH/TLS notification
 ;;;
 

--- a/elisp/mew-highlight.el
+++ b/elisp/mew-highlight.el
@@ -285,22 +285,29 @@
     (goto-char beg)
     (mew-elet
      (let ((regex1 "^BIMI-Indicator: *\\(.*\\)\n")
+	   (wmsg " not found 'bimi=pass' in Authentication-Results: header.\n")
 	   overlay bimi-logo bimi-pass svg64 beg0 end0)
        (setq bimi-pass (string-match "\\bbimi=pass\\b" (or (mew-header-get-value "Authentication-Results:") "")))
-       (when (and (or bimi-pass (not mew-use-bimi-status-check))
-		  (re-search-forward regex1 end t))
+       (when (re-search-forward regex1 end t)
 	 (setq beg0 (match-beginning 0))
 	 (setq end0 (match-end 0))
 	 (setq svg64 (match-string-no-properties 1))
-	 (when (image-type-available-p 'svg)
-	   (setq bimi-logo (create-image (mew-base64-decode-string svg64) 'svg t
-					 :width mew-bimi-size :height mew-bimi-size :ascent 'center)))
-	 (when bimi-logo
-	   (setq overlay (mew-overlay-make beg0 end0))
-	   (overlay-put overlay 'invisible t)
-	   (save-restriction
-	     (narrow-to-region beg end)
-	     (mew-bimi-display bimi-logo))))))))
+	 (cond
+	  ((and mew-use-bimi-status-check (not bimi-pass))
+	   (goto-char beg0)
+	   (insert mew-x-mew: wmsg)
+	   (setq overlay (mew-overlay-make beg0 (point)))
+	   (overlay-put overlay 'face 'mew-face-header-warning))
+	  (t
+	   (when (image-type-available-p 'svg)
+	     (setq bimi-logo (create-image (mew-base64-decode-string svg64) 'svg t
+					   :width mew-bimi-size :height mew-bimi-size :ascent 'center)))
+	   (when bimi-logo
+	     (setq overlay (mew-overlay-make beg0 end0))
+	     (overlay-put overlay 'invisible t)
+	     (save-restriction
+	       (narrow-to-region beg end)
+	       (mew-bimi-display bimi-logo))))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/elisp/mew-highlight.el
+++ b/elisp/mew-highlight.el
@@ -286,12 +286,12 @@
     (mew-elet
      (let ((regex1 "^BIMI-Indicator: *\\(.*\\)\n")
 	   (wmsg " not found 'bimi=pass' in Authentication-Results: header.\n")
-	   overlay bimi-logo bimi-pass svg64 beg0 end0)
+	   overlay bimi-logo bimi-pass svgb64 beg0 end0 scale)
        (setq bimi-pass (string-match "\\bbimi=pass\\b" (or (mew-header-get-value "Authentication-Results:") "")))
        (when (re-search-forward regex1 end t)
 	 (setq beg0 (match-beginning 0))
 	 (setq end0 (match-end 0))
-	 (setq svg64 (match-string-no-properties 1))
+	 (setq svgb64 (match-string-no-properties 1))
 	 (cond
 	  ((and mew-use-bimi-status-check (not bimi-pass))
 	   (goto-char beg0)
@@ -300,8 +300,12 @@
 	   (overlay-put overlay 'face 'mew-face-header-warning))
 	  (t
 	   (when (image-type-available-p 'svg)
-	     (setq bimi-logo (create-image (mew-base64-decode-string svg64) 'svg t
-					   :width mew-bimi-size :height mew-bimi-size :ascent 'center)))
+	     (if (boundp 'text-scale-mode)
+		 (setq scale (expt text-scale-mode-step text-scale-mode-amount))
+	       (setq scale 1.0)
+	       )
+	     (setq bimi-logo (create-image (mew-base64-decode-string svgb64) 'svg t
+					   :width (round (* mew-bimi-logo-size scale)) :ascent 'center)))
 	   (when bimi-logo
 	     (setq overlay (mew-overlay-make beg0 end0))
 	     (overlay-put overlay 'invisible t)

--- a/elisp/mew-highlight.el
+++ b/elisp/mew-highlight.el
@@ -267,6 +267,43 @@
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; BIMI
+;;;
+
+(defun mew-highlight-bimi (beg end)
+  "Display BIMI logo."
+  (if (and mew-use-highlight-bimi
+	   window-system
+	   (fboundp mew-highlight-bimi-function))
+      (funcall mew-highlight-bimi-function beg end)))
+
+(defvar mew-highlight-bimi-function (if mew-icon-p 'mew-highlight-bimi-original)
+  "*A function to display BIMI logo.")
+
+(defun mew-highlight-bimi-original (beg end)
+  (save-excursion
+    (goto-char beg)
+    (mew-elet
+     (let ((regex1 "^BIMI-Indicator: *\\(.*\\)\n")
+	   overlay bimi-logo bimi-pass svg64 beg0 end0)
+       (setq bimi-pass (string-match "\\bbimi=pass\\b" (or (mew-header-get-value "Authentication-Results:") "")))
+       (when (and (or bimi-pass (not mew-use-bimi-status-check))
+		  (re-search-forward regex1 end t))
+	 (setq beg0 (match-beginning 0))
+	 (setq end0 (match-end 0))
+	 (setq svg64 (match-string-no-properties 1))
+	 (when (image-type-available-p 'svg)
+	   (setq bimi-logo (create-image (mew-base64-decode-string svg64) 'svg t
+					 :width mew-bimi-size :height mew-bimi-size :ascent 'center)))
+	 (when bimi-logo
+	   (setq overlay (mew-overlay-make beg0 end0))
+	   (overlay-put overlay 'invisible t)
+	   (save-restriction
+	     (narrow-to-region beg end)
+	     (mew-bimi-display bimi-logo))))))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; Cooking
 ;;;
 
@@ -380,3 +417,4 @@
 ;; IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;;; mew-highlight.el ends here
+

--- a/elisp/mew-highlight.el
+++ b/elisp/mew-highlight.el
@@ -285,16 +285,14 @@
     (goto-char beg)
     (mew-elet
      (let ((regex1 "^BIMI-Indicator: *\\(.*\\)\n")
-	   (wmsg " No 'bimi=pass' in Authentication-Results\n")
-	   overlay bimi-logo bimi-pass svgb64 beg0 end0 scale)
+	   (wmsg " No 'bimi=pass' in Authentication-Results: regarding BIMI-Indicator:\n")
+	   overlay bimi-logo bimi-pass svgb64 scale)
        (setq bimi-pass (string-match "\\bbimi=pass\\b" (or (mew-header-get-value "Authentication-Results:") "")))
        (when (re-search-forward regex1 end t)
-	 (setq beg0 (match-beginning 0))
-	 (setq end0 (match-end 0))
 	 (setq svgb64 (match-string-no-properties 1))
 	 (cond
 	  ((and mew-use-bimi-status-check (not bimi-pass))
-	   (goto-char beg0)
+	   (goto-char end)
 	   (insert mew-x-mew:)
 	   (setq overlay (mew-overlay-make (- (point) (length mew-x-mew:)) (point)))
 	   (overlay-put overlay 'face 'mew-face-header-important)
@@ -305,13 +303,10 @@
 	   (when (image-type-available-p 'svg)
 	     (if (boundp 'text-scale-mode)
 		 (setq scale (expt text-scale-mode-step text-scale-mode-amount))
-	       (setq scale 1.0)
-	       )
+	       (setq scale 1.0))
 	     (setq bimi-logo (create-image (mew-base64-decode-string svgb64) 'svg t
 					   :width (round (* mew-bimi-logo-size scale)) :ascent 'center)))
 	   (when bimi-logo
-	     (setq overlay (mew-overlay-make beg0 end0))
-	     (overlay-put overlay 'invisible t)
 	     (save-restriction
 	       (narrow-to-region beg end)
 	       (mew-bimi-display bimi-logo))))))))))

--- a/elisp/mew-highlight.el
+++ b/elisp/mew-highlight.el
@@ -285,7 +285,7 @@
     (goto-char beg)
     (mew-elet
      (let ((regex1 "^BIMI-Indicator: *\\(.*\\)\n")
-	   (wmsg " not found 'bimi=pass' in Authentication-Results: header.\n")
+	   (wmsg " No 'bimi=pass' in Authentication-Results\n")
 	   overlay bimi-logo bimi-pass svgb64 beg0 end0 scale)
        (setq bimi-pass (string-match "\\bbimi=pass\\b" (or (mew-header-get-value "Authentication-Results:") "")))
        (when (re-search-forward regex1 end t)
@@ -295,9 +295,12 @@
 	 (cond
 	  ((and mew-use-bimi-status-check (not bimi-pass))
 	   (goto-char beg0)
-	   (insert mew-x-mew: wmsg)
-	   (setq overlay (mew-overlay-make beg0 (point)))
-	   (overlay-put overlay 'face 'mew-face-header-warning))
+	   (insert mew-x-mew:)
+	   (setq overlay (mew-overlay-make (- (point) (length mew-x-mew:)) (point)))
+	   (overlay-put overlay 'face 'mew-face-header-important)
+	   (insert wmsg)
+	   (setq overlay (mew-overlay-make (- (point) (length wmsg)) (point)))
+	   (overlay-put overlay 'face 'mew-face-header-xmew))
 	  (t
 	   (when (image-type-available-p 'svg)
 	     (if (boundp 'text-scale-mode)
@@ -428,4 +431,3 @@
 ;; IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ;;; mew-highlight.el ends here
-

--- a/elisp/mew-key.el
+++ b/elisp/mew-key.el
@@ -123,6 +123,7 @@
   (define-key mew-summary-mode-map "\C-c\C-z" 'mew-summary-decode-old-pgp)
   (define-key mew-summary-mode-map "\C-c\C-q" 'mew-summary-kill)
   (define-key mew-summary-mode-map "\C-c\C-x" 'mew-summary-x-face)
+  (define-key mew-summary-mode-map "\C-c\C-y" 'mew-summary-bimi)
   (define-key mew-summary-mode-map "\C-c\C-k" 'mew-summary-kill-subprocess)
   (define-key mew-summary-mode-map "^"    'mew-summary-parent)
   (define-key mew-summary-mode-map "&"    'mew-summary-child)
@@ -249,6 +250,7 @@
      ["Save"                           mew-summary-save              t]
      ["Convert body's character set"   mew-summary-convert-local-cs  t]
      ["Display X-Face"                 mew-summary-x-face            t]
+     ["Display BIMI logo"              mew-summary-bimi              t]
      )
     ("Write/Reply/Forward"
      ["Write"               mew-summary-send   t]

--- a/elisp/mew-summary4.el
+++ b/elisp/mew-summary4.el
@@ -388,6 +388,25 @@ If executed with `\\[universal-argument]', coding-system is asked."
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
+;;; BIMI-Indicator:
+;;;
+
+(defun mew-summary-bimi ()
+  "Display BIMI logo."
+  (interactive)
+  (mew-summary-msg
+   (let ((file (mew-make-temp-name)) bimi)
+     (with-current-buffer (mew-buffer-message)
+       (setq bimi (base64-decode-string (mew-header-get-value mew-bimi-indicator:))))
+     (when bimi
+       (with-temp-buffer
+	 (insert bimi)
+	 (mew-frwlet mew-cs-dummy mew-cs-text-for-write
+	   (write-region (point-min) (point-max) file nil 'no-msg)))
+       (mew-mime-image-ext file)))))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
 ;;; Calling a command
 ;;;
 

--- a/elisp/mew-vars.el
+++ b/elisp/mew-vars.el
@@ -2935,7 +2935,7 @@ in Summary/Virtual mode."
   :group 'mew-highlight
   :type 'boolean)
 
-(defcustom mew-bimi-size 24
+(defcustom mew-bimi-logo-size 24
   "*Number of BIMI logo size."
   :group 'mew-highlight
   :type 'integer)

--- a/elisp/mew-vars.el
+++ b/elisp/mew-vars.el
@@ -2925,6 +2925,21 @@ in Summary/Virtual mode."
   :group 'mew-highlight
   :type 'boolean)
 
+(defcustom mew-use-highlight-bimi mew-icon-p
+  "*If non-nil, display BIMI logo in Message mode."
+  :group 'mew-highlight
+  :type 'boolean)
+
+(defcustom mew-use-bimi-status-check t
+  "*If non-nil, check BIMI status before displaying BIMI logo."
+  :group 'mew-highlight
+  :type 'boolean)
+
+(defcustom mew-bimi-size 24
+  "*Number of BIMI logo size."
+  :group 'mew-highlight
+  :type 'integer)
+
 ;;;
 ;;; Styles and colors
 ;;;

--- a/elisp/mew-vars2.el
+++ b/elisp/mew-vars2.el
@@ -558,7 +558,7 @@ the next version of Mew.")
      ("hardfail" mew-face-header-xmew-bad
       "fail" mew-face-header-xmew-bad
       "softfail" mew-face-header-xmew-bad))
-    ("^BIMI-Indicator:$" nil)
+    ("^BIMI-" nil)
     ("^Delivered-" nil)
     ("^List-" nil) ;; RFC 2369
     ;;    ("^Content-" t)

--- a/elisp/mew-vars2.el
+++ b/elisp/mew-vars2.el
@@ -558,6 +558,7 @@ the next version of Mew.")
      ("hardfail" mew-face-header-xmew-bad
       "fail" mew-face-header-xmew-bad
       "softfail" mew-face-header-xmew-bad))
+    ("^BIMI-Indicator:$" nil)
     ("^Delivered-" nil)
     ("^List-" nil) ;; RFC 2369
     ;;    ("^Content-" t)

--- a/elisp/mew-vars2.el
+++ b/elisp/mew-vars2.el
@@ -489,6 +489,7 @@ the next version of Mew.")
     (,mew-in-reply-to:   unstruct   unstruct)
     (,mew-x-face:	 unstruct   unstruct)
     (,mew-face:          unstruct   unstruct)
+    (,mew-bimi-indicator:      unstruct unstruct)
     ("Authentication-Results:" unstruct struct2) ;; capitalized
     ("Domainkey-Signature:"    unstruct unstruct) ;; capitalized
     ("Dkim-Signature:"         unstruct unstruct)) ;; capitalized


### PR DESCRIPTION
### Feature
- Decode "BIMI-Indicator:" header in a mail and display BIMI logo on From: line in Message mode.
- "BIMI-Indicator:" is defined in an IETF draft "Brand Indicators for Message Identification (BIMI) draft-brand-indicators-for-message-identification-10"
https://datatracker.ietf.org/doc/draft-brand-indicators-for-message-identification/

### Implementation
- Copied and modified existing codes for "X-Face:" header in mew-highlight.el and so on
- No need for additional commands outside emacs

### Note
- This implementation doesn't verify DMARC or BIMI by itself. It relies on "BIMI-Indicator:" header in mails.
- If "mew-use-bimi-status-check" variable is non-nil(default), BIMI logo is displayed when "bimi=pass" is found in any "Authentication-Results:" in addition to "BIMI-Indicator:"
- BIMI-Logo-Preference is ignored. Both a BIMI logo and a personal avatar(X-Face icon) are displayed (if available).

### Sample
- Headers found in a mail received from a POP server of "nifty" (a provider).
- Not confirmed whether "nifty" is compliant with the IETF draft.
```
Authentication-Results: nifty.com;
    dmarc=pass header.from=mail.smbcnikko.co.jp;
    dkim=pass;
    spf=pass smtp.mailfrom=gmail.com;
    sender-id=SoftFail (pra) header.From=mail.smbcnikko.co.jp;
    bimi=pass header.d=smbcnikko.co.jp header.selector=default
        policy.authority-uri=https://vmc.digicert.com/d6767594-90a1-49d6-a339-f6bbb6ba3862.pem
        policy.indicator-uri=https://vmc.digicert.com/d6767594-90a1-49d6-a339-f6bbb6ba3862.svg
        policy.authority=pass
        policy.indicator-hash=c5c7cc8e
BIMI-Location: v=BIMI1; l=https://vmc.digicert.com/d6767594-90a1-49d6-a339-f6bbb6ba3862.svg
 a=https://vmc.digicert.com/d6767594-90a1-49d6-a339-f6bbb6ba3862.pem
BIMI-Indicator: PD94bWwgdmVyc2lvbj0iMS4wIiBlbmNvZGluZz0idXRmLTgiPz4KPHN2ZyB2ZXJzaW9uPSIxLjIi
 IGJhc2VQcm9maWxlPSJ0aW55LXBzIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmci
 IHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2aWV3Qm94PSIwIDAg
 MTcwIDE3MCIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSI+Cjx0aXRsZT5TTUJDIE5pa2tvIFNlY3VyaXRp
 ZXMgSW5jLjwvdGl0bGU+CiAgPGc+CiAgICA8cG9seWdvbiBwb2ludHM9IjY4LjggNzQuMSA2OC44
 IDEzNi44IDQzLjYgMTQ3LjkgNDMuNiA4NSA2OC44IDc0LjEiIGZpbGw9IiNlNjAwM2UiLz4KICAg
 IDxwb2x5Z29uIHBvaW50cz0iMTI2LjQgMjIuMSAxMjYuNCA4NC45IDEwMS4yIDk1LjkgMTAxLjIg
 MzMuMSAxMjYuNCAyMi4xIiBmaWxsPSIjZTYwMDNlIi8+CiAgICA8cG9seWdvbiBwb2ludHM9Ijk3
 LjcgMzQuNSA5Ny43IDk3LjQgNzIuMyAxMzUuNCA3Mi4zIDcyLjcgOTcuNyAzNC41IiBmaWxsPSIj
 ZTYwMDNlIi8+CiAgPC9nPgo8L3N2Zz4=
```