### PR TITLE
Use pdf-tools to display a PDF file attached to an email

### DIFF
--- a/elisp/mew-gemacs.el
+++ b/elisp/mew-gemacs.el
@@ -433,6 +433,16 @@ with fitting to frame size"
     ;; for Mac
     (define-key mew-message-mode-map [M-down-mouse-1] 'mew-browse-url-at-mouse))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; PDF
+;;;
+
+(defun mew-pdf-tools-view ()
+  (find-file mew-pdf-file)
+  (pdf-view-mode) ;; necessary? because mew-pdf-file always points to a PDF file
+  (setq mew-pdf-tools-buffer (current-buffer)))
+
 (provide 'mew-gemacs)
 
 ;;; Copyright Notice:

--- a/elisp/mew-vars2.el
+++ b/elisp/mew-vars2.el
@@ -981,6 +981,21 @@ An example is as follows:
     (or (assoc case mew-config-alist)
 	(assoc (intern case) mew-config-alist))))
 
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;;
+;;; pdf-tools
+;;;
+
+(defvar mew-pdf-tools-use nil) ;; Set t if you use pdf-tools to view a PDF file
+(defvar mew-pdf-file nil) ;; full path and name of the PDF file (defined as a global variable)
+(defvar mew-pdf-tools-buffer nil) ;; buffer name to show the PDF file
+(defvar mew-pdf-tools-function 'pdf-tools-install) ;; Set one of the function names in pdf-tools
+
+(defun mew-pdf-tools-installed-p ()
+  (and (fboundp mew-pdf-tools-function)
+       (boundp 'pdf-info-epdfinfo-program)
+       (file-exists-p pdf-info-epdfinfo-program)))
+
 (provide 'mew-vars2)
 
 ;;; Copyright Notice:

--- a/elisp/mew.el
+++ b/elisp/mew.el
@@ -185,6 +185,7 @@ CONTINUE, YANK-ACTION and SEND-ACTIONS are ignored."
 	  (mew-mark-init)
 	  (mew-config-init)
 	  (mew-subprocess-init)
+	  (mew-pdf-tools-init)
 	  (mew-rotate-log-files mew-smtp-log-file)
 	  (mew-rotate-log-files mew-nntp-log-file)
 	  (mew-rotate-log-files mew-refile-log-file))
@@ -625,6 +626,16 @@ Mew remain, so you can resume with buffer operations."
   (mew-quit-toolbar-update)
   (run-hooks 'mew-suspend-hook))
 
+(defun mew-pdf-tools-init ()
+  (add-hook 'kill-emacs-hook 'mew-pdf-tools-clean-up))
+
+(defun mew-pdf-tools-clean-up ()
+  (remove-hook 'kill-emacs-hook 'mew-pdf-tools-clean-up)
+  (mew-remove-buffer mew-pdf-tools-buffer)
+  (setq mew-pdf-tools-buffer nil)
+  (mew-delete-file mew-pdf-file)
+  (setq mew-pdf-file nil))
+
 (defun mew-summary-quit ()
   "Quit Mew. All buffers of Mew are erased."
   (interactive)
@@ -635,6 +646,7 @@ Mew remain, so you can resume with buffer operations."
     (mew-buffer-clean-up (mew-folder-regex mew-draft-folder)) ;; +draft/*
     (mew-buffer-clean-up mew-buffer-regex) ;; other buffers
     ;;
+    (mew-pdf-tools-clean-up)
     (mew-sinfo-clean-up)
     (mew-buffers-clean-up) ;; Summary mode and Virtual mode
     ;;


### PR DESCRIPTION
`(setq mew-pdf-tools-use t)` is written in an initialization file, e.g., `~/.emacs.d/init.el`.
The default value is `nil`.

An execution file of `epdfinfo` used by pdf-tools is necessary to work.
To get the file, open any PDF file, then it asks to make 'epdfinfo' by compiling.
Or get a binary file from the Internet (e.g., in case of Windows MSYS2).
The elisp of this modification checks whether the file exists or not.
(The check is done by `(defun mew-pdf-tools-installed-p ...)` in `mew-var2.el`.)
It's safe if pdf-tools opens any PDF file at once before using this elisp.

Another buffer is created to display a PDF file because the PDF file is opened in a major mode.
When displaying the PDF file, switch to the buffer of the PDF file using `C-x o`. Then you can scroll the PDF file with `C-n`, `C-p`, `n`, `p`, etc. (You can use key-bindings in pdf-tools.)

---
In `mew.el`, the location of `(defun mew-pdf-tools-init ...)` and `(defun mew-pdf-tools-clean-up ...)` is correct or not. (Those `defun` should be in another `mew-*.el` file?)

And, the location/order of `(mew-pdf-tools-init)` in `(defun mew-set-environment ...)` is correct or not. (Please consider the order of `(add-hook 'kill-emacs-hook ...)`.)

Also, the location/order of `(mew-pdf-tools-clean-up)` in `(defun mew-summary-quit ...)` is correct or not.

I'm afraid of those.

---
In `mew-gemacs.el`, I think `(pdf-view-mode)` is not necessary.
But it's written just in case.

And, a variable of `mew-pdf-file` contains a full path of a PDF file or `nil`.
Thus, I think `(stringp mew-pdf-file)` in `mew-mime.el` is not necessary.
(But it's possible to store non-strings in it outside of Mew.
So, it's also written just in case.)