### PR TITLE
feat: add "--pinentry-mode loopback" to "--list-packets"

### DIFF
--- a/elisp/mew-passwd.el
+++ b/elisp/mew-passwd.el
@@ -413,7 +413,7 @@
 
 (defun mew-passwd-get-cache-id (file)
   (with-temp-buffer
-    (call-process mew-prog-passwd nil t nil "--list-packets" file)
+    (apply 'call-process mew-prog-passwd nil t nil (mew-passwd-adjust-args (list "--list-packets" file)))
     (goto-char (point-min))
     (when (re-search-forward "salt \\([^ ,]+\\)," nil t)
       (concat "S" (match-string 1)))))


### PR DESCRIPTION
Avoid entering the master password twice when loading the password file
cf. #218 item No.1
