### PR TITLE
XOAUTH2 for POP

### DIFF
--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -518,7 +518,7 @@
 	 (tag (mew-pop-passtag pnm))
          (auth-string (mew-xoauth2-auth-string user tag (mew-pop-get-case pnm))))
     (mew-pop-process-send-string pro "AUTH XOAUTH2 %s" auth-string)
-    (mew-smtp-set-status pnm "auth-xoauth2")))
+    (mew-pop-set-status pnm "xoauth2")))
 
 (defun mew-pop-command-auth-cram-md5 (pro pnm)
   (mew-pop-process-send-string pro "AUTH CRAM-MD5")

--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -44,7 +44,8 @@
 (defvar mew-pop-fsm
   '(("greeting"      nil ("\\+OK" . "capa"))
     ("capa"          t   ("\\+OK" . "auth") ("-ERR" . "pswd"))
-    ("xoauth2"       nil ("\\+OK" . "list") ("-ERR" . "wpwd"))
+    ("auth-xoauth2"  nil ("\\+OK" . "token-xoauth2") ("-ERR" . "wpwd"))
+    ("token-xoauth2" nil ("\\+OK" . "list") ("-ERR" . "wpwd"))
     ("auth-cram-md5" nil ("\\+OK" . "pwd-cram-md5") ("-ERR" . "wpwd"))
     ("pwd-cram-md5"  nil ("\\+OK" . "list") ("-ERR" . "wpwd"))
     ("auth-plain"    nil ("\\+OK" . "pwd-plain") ("-ERR" . "wpwd"))
@@ -514,11 +515,17 @@
   (nth 1 (mew-assoc-case-equal auth mew-pop-auth-alist 0)))
 
 (defun mew-pop-command-auth-xoauth2 (pro pnm)
+  ;; MS365 does not accept "AUTH XOAUTH2 <token>" in a single line.
+  ;; It requires the SASL continuation exchange: send "AUTH XOAUTH2",
+  ;; wait for the "+ " response, then send the token separately.
+  (mew-pop-process-send-string pro "AUTH XOAUTH2")
+  (mew-pop-set-status pnm "auth-xoauth2"))
+
+(defun mew-pop-command-token-xoauth2 (pro pnm)
   (let* ((user (mew-pop-get-user pnm))
 	 (tag (mew-pop-passtag pnm))
          (auth-string (mew-xoauth2-auth-string user tag (mew-pop-get-case pnm))))
-    (mew-pop-process-send-string pro "AUTH XOAUTH2 %s" auth-string)
-    (mew-pop-set-status pnm "xoauth2")))
+    (mew-pop-process-send-string pro "%s" auth-string)))
 
 (defun mew-pop-command-auth-cram-md5 (pro pnm)
   (mew-pop-process-send-string pro "AUTH CRAM-MD5")


### PR DESCRIPTION
### POPのXOAUTH2認証でエラー

```
	 (pop-server        "pop.gmail.com")
	 (pop-auth          t)
```
の設定によりXOAUTH2認証しようとすると以下のようなエラーとなります。

```
Debugger entered--Lisp error: (wrong-type-argument number-or-marker-p "auth-xoauth2")
  =("auth-xoauth2" 0)
  (or (null left) (= left 0))
  (cond ((or (null left) (= left 0))) ((= left 1) (setq msg2 " (1 message left)")) (t (setq msg2 (format " (%d messages left)" left))))
  (let (msg2) (cond ((or (null left) (= left 0))) ((= left 1) (setq msg2 " (1 message left)")) (t (setq msg2 (format " (%d messages left)" left)))) (if msg2 (setq msg (concat msg msg2))) (mew-pop-message pnm msg))
```

認証自体は通っています。(以下、空行詰めてます)

```
<=SEND=>
AUTH XOAUTH2 blahblahblah
<AUTH>
+OK Welcome.
<=SEND=>
QUIT
<QUIT>
+OK Farewell.
<POP SENTINEL>
connection broken by remote peer
```


https://github.com/kazu-yamamoto/Mew/issues/172#issuecomment-2322814452
でも指摘がありましたが、`mew-smtp-set-status` ではなく `mew-pop-set-status` であるべきではないでしょうか。

### MS365 POPのXOAUTH2認証でエラー
MS365のPOPサーバーに対してXOAUTH2認証しようとすると、上記を修正しても `XOAUTH2 password is wrong!`となります。
`-ERR Protocol error. Connection is closed. 10`が返ってきています。

```
<=SEND=>
AUTH XOAUTH2 blahblahblah
<XOAUTH2>
-ERR Protocol error. Connection is closed. 10
<=SEND=>
QUIT
<POP SENTINEL>
connection broken by remote peer
```

これはMS365の制限で、
AUTH XOAUTH2 token という1行では受け付けず、AUTH XOAUTH2 と token を2行に分けて送る必要があるようです。
https://learn.microsoft.com/en-us/exchange/client-developer/legacy-protocols/how-to-authenticate-an-imap-pop-smtp-application-by-using-oauth#pop-protocol-exchange

> To authenticate a POP server connection, the client will have to respond with an AUTH command split into two lines in the following format:

```
AUTH XOAUTH2 
<base64 string in XOAUTH2 format>
```
本PRにより、"+ " を待ってからtokenを送るようにすれば以下のように認証に成功します。

```
<=SEND=>
AUTH XOAUTH2
<AUTH-XOAUTH2>
+ 
<=SEND=>
blahblahblah
<TOKEN-XOAUTH2>
+OK User successfully authenticated.
```

ちなみにThunderbirdでは以下で対応したようです。コメントしか読めていませんが。ご参考まで。
https://bugzilla.mozilla.org/show_bug.cgi?id=1778576

個人的にはMS365のPOPは使っていませんし、根本的にはMS365の問題のはずですし、IMAPでなくPOPを使う需要も多くないと想像しますので、こちらの修正の必要性はあまり感じていません。問題に当たってしまったのでご報告、というレベルです。既知でしたら申し訳ありません。
