### PR TITLE
Allow mewl to accept non-numeric paths from stdin

### DIFF
--- a/bin/mewl.c
+++ b/bin/mewl.c
@@ -610,6 +610,17 @@ search_string(char *key, char *value, int case_sensitive) {
 			break;
 	}
 	return FALSE;
+  }
+
+private
+int ends_with(const char *str, const char *suffix) {
+	if (!str || !suffix) return FALSE;
+
+	size_t str_len = strlen(str);
+	size_t suffix_len = strlen(suffix);
+
+	if (str_len < suffix_len) return FALSE;
+	return strncmp(str + str_len - suffix_len, suffix, suffix_len) == 0;
 }
 
 /****************************************************************
@@ -907,25 +918,16 @@ exec_getfile(char **filename, char **foldername) {
 		if(default_fld_error_flag != 0)
 			warn_exit("default folder is not exist.");
 		while (*p == SP || *p == TAB) p++;
-		if (isdigit((unsigned char)*p) == 0) continue;
 		*filename = p;
-		while (isdigit((unsigned char)*p)) p++;
-		if (STRCMP(p, Suffix)==0) {
-			r = p;
-			p = p + Suffix_len;
-		} else
+		if (ends_with(p, Suffix))
+			r = p + strlen(p) - Suffix_len;
+		else
 			r = NULL;
-		*p = NUL;
 		fp = fopen(*filename, FDREAD);
-		if (fp != NULL) {
-			if (r != NULL) *r = NUL;
-			return fp;
-		}
-		if (r != NULL) {
-			*r = NUL;
-			fp = fopen(*filename, FDREAD);
-			if (fp != NULL) return fp;
-		}
+		if (r != NULL) *r = NUL; // remove suffix
+		if (fp != NULL) return fp;
+		fp = fopen(*filename, FDREAD); // try again without suffix
+		if (fp != NULL) return fp;
 	}
 	return NULL;
 }


### PR DESCRIPTION
The `exec_get_files` function is called when executing either `mew -i FILE` or `mew -e COMMAND`, receiving a list of file names (paths) of emails to be processed from the output of the FILE or COMMAND.

For instance, the full-text search functionality of `k/` sends search results to mewl using the former. The integration with incm, which retrieves emails from MBOX files, utilizes the latter.

The current implementation of `exec_get_filename` assumes that the path consists solely of a number and suffix, ignoring anything else.

This PR aims to increase flexibility in FILE and COMMAND output by allowing `exec_getfile` to accept arbitrary non-numeric paths.

This change allows us to directly pass search results like `notmuch search --output=files Emacs Mew` to mewl without modification.

    notmuch search --output=files Emacs Mew

    /home/nom/notmuch-archive/8f/8f0add61613e6a902db52d182d37aa95e6ffbc2b.eml
    /home/nom/notmuch-archive/4d/4d9f72986609aaec69aac44dc1f1fd64a45a2953.eml
    /home/nom/notmuch-archive/d8/d8610e5fc081ceb623340d9a4fdf2c85a45fbe19.eml
    :

    notmuch search --output=files Emacs Mew | mewl -i - -x .eml

    Folder: +inbox
    Filename: /home/nom/notmuch-archive/8f/8f0add61613e6a902db52d182d37aa95e6ffbc2b
    Subject: XXXXXXXXXXXXXXXXXXXX
    Date: Thu, 01 Jan 2026 09:10:35 +0900 (JST)
    From: XXXXXXXXXXXXXXXXXX
    To: XXXXXXXXXXXXXXXXXX
    Content-Type: Text/Plain; charset=iso-2022-jp
    Content-Transfer-Encoding: 7bit
    Message-Id: <20251001.091035.1738021690740704221.nom@okayama-u.ac.jp>
    In-Reply-To: <20250930.213926.1837602827391854072.koka@hirosaki-u.ac.jp>
    References:     <20250930.213926.1837602827391854072.koka@hirosaki-u.ac.jp>
    :

Since Mew's virtual mode already accepts arbitrary paths, mewl should also adapt to this.

-   Reference:<https://mew.org/ml-archives/mew-dist/2000-June/013219.html>
