### PR TITLE
Timestamp-related suggestions for Mew

### DIFF
--- a/elisp/mew-cache.el
+++ b/elisp/mew-cache.el
@@ -27,7 +27,7 @@
 (defun mew-cinfo-equal (fld msg time size)
   (and (string= (mew-cinfo-get-fld) fld)
        (string= (mew-cinfo-get-msg) msg)
-       (equal (mew-cinfo-get-time) time)
+       (time-equal-p (mew-cinfo-get-time) time)
        (eq (mew-cinfo-get-size) size)))
 
 (defun mew-cache-dinfo-get-decode-broken (buf)

--- a/elisp/mew-config.el
+++ b/elisp/mew-config.el
@@ -226,7 +226,7 @@
   (let* ((random (format "%08d" (mew-random)))
 	 (domain (mew-smtp-msgid-domain case))
 	 (user (mew-smtp-msgid-user case))
-	 (time (mew-time-ctz-to-msgid (mew-current-time))))
+	 (time (mew-time-ctz-to-msgid nil)))
     (concat "<" time "." random "." user "@" domain ">")))
 
 (defun mew-use-smtp-auth (&optional case)
@@ -374,7 +374,7 @@
   (let* ((random (format "%08d" (mew-random)))
 	 (domain (mew-nntp-msgid-domain case))
 	 (user (mew-nntp-msgid-user case))
-	 (time (mew-time-ctz-to-msgid (mew-current-time))))
+	 (time (mew-time-ctz-to-msgid nil)))
     (concat "<" time "." random "." user "@" domain ">")))
 ;;
 

--- a/elisp/mew-encode.el
+++ b/elisp/mew-encode.el
@@ -242,7 +242,7 @@
 ;;;
 
 (defun mew-encode-id-date (_pnm msgid &optional resentp)
-  (let ((time (mew-current-time)))
+  (let ((time (current-time)))
     (cond
      (resentp
       (mew-header-delete-lines (list mew-resent-date: mew-resent-message-id:))

--- a/elisp/mew-exec.el
+++ b/elisp/mew-exec.el
@@ -616,7 +616,7 @@ the queue, type '\\[mew-summary-send-message]' in the queue online."
 	(mew-lisp-save file-info job 'nobackup 'unlimit)
 	(with-temp-buffer
 	  (mew-header-insert mew-subj: (format "IMAP jobs for %s" fld))
-	  (mew-header-insert mew-date: (mew-time-ctz-to-rfc (mew-current-time)))
+	  (mew-header-insert mew-date: (mew-time-ctz-to-rfc nil))
 	  (mew-header-insert mew-from: "Mew IMAP manager")
 	  (insert "\n")
 	  (insert "Messages to be refiled:\n")

--- a/elisp/mew-ext.el
+++ b/elisp/mew-ext.el
@@ -144,8 +144,9 @@
 (defun mew-create-content-id ()
   ;; this is not unique if used with very short interval.
   ;; but it's ok
-  (format "<%s.%s.%s@%s>" (nth 0 (mew-current-time)) (nth 1 (mew-current-time))
-	  (emacs-pid) (system-name)))
+  (let ((now (time-convert nil 'integer)))
+    (format "<%s.%s.%s@%s>" (ash now -16) (logand now 65535)
+	    (emacs-pid) (system-name))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1476,12 +1476,13 @@ by side-effect."
 	  (setq year (+ year 2000)))
 	 ((< year 150)
 	  (setq year (+ year 1900))))
-	(if (or (< year 1970) (>= year 2038))
-	    ;; invalid data
-	    (mew-time-ctz-to-sortkey-invalid sec min hour day mon year)
-	  (mew-time-ctz-to-sortkey (encode-time
-				    (list sec min hour day mon year
-					  nil -1 (and tzadj tmzn))))))))
+	(condition-case nil
+	    (mew-time-ctz-to-sortkey
+	     (encode-time (list sec min hour day mon year
+				nil -1 (and tzadj tmzn))))
+	  (error
+	   ;; invalid data
+	   (mew-time-ctz-to-sortkey-invalid sec min hour day mon year))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1455,8 +1455,7 @@ by side-effect."
 
 ;; "20000726121835"
 (defun mew-time-ctz-to-sortkey (time)
-  (let ((system-time-locale "C"))
-    (format-time-string "%Y%m%d%H%M%S" time)))
+  (format-time-string "%Y%m%d%H%M%S" time))
 
 (defun mew-time-ctz-to-sortkey-invalid (sec min hour day mon year)
   (format "%04d%02d%02d%02d%02d%02d" year mon day hour min sec))
@@ -1506,13 +1505,11 @@ by side-effect."
 
 ;; 2000/07/12 16:22:30
 (defun mew-time-ctz-to-logtime (time)
-  (let ((system-time-locale "C"))
-    (format-time-string "%Y/%m/%d %H:%M:%S" time)))
+  (format-time-string "%Y/%m/%d %H:%M:%S" time))
 
 ;; 20000712.155559
 (defun mew-time-ctz-to-msgid (time)
-  (let ((system-time-locale "C"))
-    (format-time-string "%Y%m%d.%H%M%S" time)))
+  (format-time-string "%Y%m%d.%H%M%S" time))
 
 ;;
 

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1516,17 +1516,7 @@ by side-effect."
 ;;
 
 (defun mew-time-calc (new old)
-  (let ((million 1000000)
-	(sec (+ (* 65536 (- (nth 0 new) (nth 0 old)))
-		(- (nth 1 new) (nth 1 old))))
-	(usec (- (nth 2 new) (nth 2 old))))
-    (if (< usec 0)
-        (setq sec (1- sec)
-              usec (+ usec million))
-      (if (>= usec million)
-          (setq sec (1+ sec)
-                usec (- usec million))))
-    (+ sec (/ usec (float million)))))
+  (float-time (time-subtract new old)))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1497,12 +1497,11 @@ by side-effect."
 ;; Wed, 26 Jul 2000 21:18:35 +0900 (JST)
 (defun mew-time-ctz-to-rfc (time)
   (let* ((system-time-locale "C")
-	 ;; A bug of Emacs 22.3 on Windows
-	 (time-zone-name (format-time-string "%Z" time))
-	 (date (format-time-string "%a, %d %b %Y %T %z" time)))
-    (if (string= time-zone-name "")
-	date
-      (concat date (format " (%s)" time-zone-name)))))
+	 (date (format-time-string "%a, %d %b %Y %T %z (%Z)" time)))
+    ;; Omit comment if %Z produces the empty string
+    (if (eq ?\( (aref date (- (length date) 2)))
+	(substring date -3)
+      date)))
 
 ;; 2000/07/12 16:22:30
 (defun mew-time-ctz-to-logtime (time)

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1479,9 +1479,9 @@ by side-effect."
 	(if (or (< year 1970) (>= year 2038))
 	    ;; invalid data
 	    (mew-time-ctz-to-sortkey-invalid sec min hour day mon year)
-	  (setq sec (- sec tmzn))
-	  (if tzadj (setq sec (+ sec (car (current-time-zone)))))
-	  (mew-time-ctz-to-sortkey (encode-time sec min hour day mon year))))))
+	  (mew-time-ctz-to-sortkey (encode-time
+				    (list sec min hour day mon year
+					  nil -1 (and tzadj tmzn))))))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -1536,6 +1536,14 @@ by side-effect."
 (defun mew-current-time ()
   (time-convert (current-time) 'list))
 
+;; Emacs 27 introduced time-equal-p,
+;; but Mew assumes only Emacs 26.
+(unless (fboundp 'time-equal-p)
+  (defun time-equal-p (a b)
+    "Non-nil if time values A and B are equal."
+    (not (or (time-less-p a b)
+             (time-less-p b a)))))
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;;;
 ;;; Multibyte

--- a/elisp/mew-func.el
+++ b/elisp/mew-func.el
@@ -941,7 +941,7 @@ If case is \"default\", it is not prepended."
     (nth 1 (file-attributes file))))
 
 (defun mew-file-get-time (file)
-  (time-convert (nth 5 (file-attributes file)) 'list))
+  (nth 5 (file-attributes file)))
 
 (defun mew-file-get-size (file)
   (nth 7 (file-attributes file)))
@@ -1522,9 +1522,6 @@ by side-effect."
 ;;;
 ;;; Time
 ;;;
-
-(defun mew-current-time ()
-  (time-convert (current-time) 'list))
 
 ;; Emacs 27 introduced time-equal-p,
 ;; but Mew assumes only Emacs 26.

--- a/elisp/mew-imap.el
+++ b/elisp/mew-imap.el
@@ -300,7 +300,7 @@
 	 (rmvs (mew-imap-get-rmvs pnm))
 	 (del-time (mew-imap-get-delete pnm))
 	 (range (mew-imap-get-range pnm))
-	 (ctime (mew-current-time))
+	 (ctime (current-time))
 	 rtr rtrs dels uid siz uidl old-uidl uid-time hlds flags mdb)
     (if (eq directive 'inc)
 	(setq old-uidl (mew-net-uidl-db-get (mew-imap-passtag pnm))))

--- a/elisp/mew-local.el
+++ b/elisp/mew-local.el
@@ -388,8 +388,12 @@ Binary search is used for speed reasons."
        (mew-remove-buffer buf)))))
 
 (defun mew-virtual-set-cache-time ()
-  (let* ((ctime (mew-current-time))
-	 (cache-time (list (nth 0 ctime) (nth 1 ctime))))
+  ;; Keep timestamps in (HI LO) form,
+  ;; so that files that current Mew generates
+  ;; can be read by Mew versions predating August 2026.
+  ;; This loses subsecond information.
+  (let* ((ctime (time-convert nil 'integer))
+	 (cache-time (list (ash ctime -16) (logand ctime 65535))))
     (mew-sinfo-set-cache-time cache-time)))
 
 ;;; Code:

--- a/elisp/mew-net.el
+++ b/elisp/mew-net.el
@@ -203,8 +203,7 @@
 ;;;
 
 (defun mew-time-diff (t1 t2)
-  (/ (+ (* (- (nth 0 t2) (nth 0 t1)) 65536)
-	(- (nth 1 t2) (nth 1 t1)))
+  (/ (mew-time-calc t1 t2)
      86400.0)) ;; one day (* 60 60 24)
 
 (defun mew-expired-p (time keep)
@@ -215,7 +214,7 @@
     (if (>= (mew-time-diff time (mew-file-get-time (nth 0 keep))) (nth 1 keep))
 	t))
    ((integerp keep)
-    (if (>= (mew-time-diff time (mew-current-time)) keep) t))
+    (if (>= (mew-time-diff time nil) keep) t))
    ;; ((eq keep t) t)
    ;; This case MUST not be included because messages marked with 'T'
    ;; will be deleted.

--- a/elisp/mew-oauth2.el
+++ b/elisp/mew-oauth2.el
@@ -201,7 +201,7 @@ It serves http://localhost:PORT"
 	 (access-token (gethash :access_token token))
 	 (refresh-token (gethash :refresh_token token)))
     (cond
-     ((and access-token (time-less-p (mew-current-time) expire))
+     ((and access-token (time-less-p nil expire))
       access-token)
      (refresh-token
       (let* ((json (mew-oauth2-refresh-access-token
@@ -212,7 +212,7 @@ It serves http://localhost:PORT"
 	     (expires-in (gethash "expires_in" json))
 	     (refresh-token (gethash "refresh_token" json)))
 	(setq access-token (gethash "access_token" json))
-	(setq expire (if expires-in (time-add (- expires-in 100) (mew-current-time)) nil))
+	(setq expire (if expires-in (time-add (- expires-in 100) nil) nil))
 	(puthash :access_token access-token token)
 	(if refresh-token (puthash :refresh_token refresh-token token))
 	(puthash :expire expire token)
@@ -237,7 +237,7 @@ It serves http://localhost:PORT"
 	     (expires-in (gethash "expires_in" json)))
 	(setq access-token (gethash "access_token" json))
 	(setq refresh-token (gethash "refresh_token" json))
-	(setq expire (if expires-in (time-add (- expires-in 100) (mew-current-time)) nil))
+	(setq expire (if expires-in (time-add (- expires-in 100) nil) nil))
 	(puthash :access_token access-token token)
 	(puthash :refresh_token refresh-token token)
 	(puthash :expire expire token)

--- a/elisp/mew-pop.el
+++ b/elisp/mew-pop.el
@@ -240,7 +240,10 @@
 	 (del-time (mew-pop-get-delete pnm))
 	 (bnm (mew-pop-get-bnm pnm))
 	 (range (mew-pop-get-range pnm))
-	 (ctime (mew-current-time))
+	 ;; Keep timestamps in (HI LO USEC PSEC) form,
+	 ;; so that the generated files can be read
+	 ;; by Mew versions predating August 2026.
+	 (ctime (time-convert nil 'list))
 	 (left 0)
 	 rtr rtrs dels num uid uidl old-uidl uid-time hlds)
     (cond

--- a/elisp/mew-refile.el
+++ b/elisp/mew-refile.el
@@ -644,7 +644,7 @@ with `\\[universal-argument]', it displays how the refile rules work in Message 
 	(goto-char (point-max))
 	(mew-insert-buffer-substring cbuf beg end)
 	(insert "== src=" fld " dst=" folders-str " id=" msg-id)
-	(insert " date=" (mew-time-ctz-to-logtime (mew-current-time)) "\n")))))
+	(insert " date=" (mew-time-ctz-to-logtime nil) "\n")))))
 
 (defun mew-summary-refile-unlog (fld)
   (save-excursion

--- a/elisp/mew-scan.el
+++ b/elisp/mew-scan.el
@@ -798,10 +798,7 @@ non-nil, only headers of messages are cached. If executed with
   (cond
    ((null t1) nil)
    ((null t2) t) ;; do update
-   ((> (nth 0 t1) (nth 0 t2)) t)
-   ((= (nth 0 t1) (nth 0 t2))
-    (if (> (nth 1 t1) (nth 1 t2)) t nil)) ;; nil if equal
-   (t nil)))
+   (t (time-less-p t2 t1))))
 
 (defun mew-summary-folder-dir-newp ()
   (let* ((folder (mew-summary-folder-name 'ext))

--- a/elisp/mew-thread.el
+++ b/elisp/mew-thread.el
@@ -355,23 +355,23 @@ threads are created, see `mew-use-complete-thread'."
 	(setq db (mew-thread-create-db (count-lines beg end)))
 	;;
 	(message "Making thread (first pass)...")
-	(setq tm1 (mew-current-time))
+	(setq tm1 (current-time))
 	(setq top (mew-thread-pass-1 db (mew-thread-get-iter mark iter)))
-	(setq tm2 (mew-current-time)))
+	(setq tm2 (current-time)))
       ;;
       (if (null top)
 	  (message "No target messages")
 	(message "Making thread (second pass)...")
-	(setq tm3 (mew-current-time))
+	(setq tm3 (current-time))
 	(setq top (mew-thread-pass-2 db top))
-	(setq tm4 (mew-current-time))
+	(setq tm4 (current-time))
 	;;
 	(mew-summary-setup-vfolder db top column)
 	;;
 	(message "Displaying thread...")
-	(setq tm5 (mew-current-time))
+	(setq tm5 (current-time))
 	(mew-summary-thread-print-top (mew-vinfo-get-top) column)
-	(setq tm6 (mew-current-time))
+	(setq tm6 (current-time))
 	;;
 	(mew-thread-postscript mark disp-msg)	
 	;;

--- a/elisp/mew-thread.el
+++ b/elisp/mew-thread.el
@@ -168,8 +168,9 @@ All members must have the same length."
 	(setq ofld (mew-vinfo-get-original-folder))
 	(and (equal ofld cfolder)
 	     (get-buffer ofld)
-	     (equal (mew-sinfo-get-cache-time)
-		    (progn (set-buffer ofld) (mew-sinfo-get-cache-time))))))))
+	     (time-equal-p
+	      (mew-sinfo-get-cache-time)
+	      (progn (set-buffer ofld) (mew-sinfo-get-cache-time))))))))
 
 (defun mew-summary-make-thread (&optional arg)
   "If called in Summary mode or Selection, make threads for


### PR DESCRIPTION
Hello, I see you recently ported Mew to Emacs when its variable current-time-list is nil (planned to be the default in Emacs 32). As part of my penance for making those time-related changes to Emacs many years ago, I looked over the recent Mew changes (which all seem good), and have some further suggestions to help make the time code even more solid. This pull request contains suggested patches, which are the following:
- Generalize functions like mew-time-ctz-to-rfc so that they can accept nil, meaning the current time. This better fits Emacs's time primitives and makes the callers a bit more efficient as they need not generate a data structure representing the current time.
- Use time-equal-p instead of comparing timestamps by hand, so the code is more accepting of timestamps in all formats that Emacs accepts.
- Use (time-convert nil 'integer) to generate integers directly, instead of computing them from the data structure generated by (current-time); this makes callers a bit more efficient and simpler.
- Use time-subtract instead of doing it by hand. This simplifies the code. I see from the repository history that you attempted doing that as well but reverted; I assume this was because some of the other code hadn't been adjusted yet and I hope this series of patches makes the simplification possible.
- Use time-less-p instead of doing things by hand.
- Instead of using a shim mew-current-time to always use list format, adjust the code so that it doesn't care which format timestamps use.
- Fix an obscure daylight-saving bug in mew-time-rfc-to-sortkey.
- Fix a Y2038 bug in mew-time-rfc-to-sortkey.
- Avoid binding system-time-locale when it's not necessary.
Please let me know if you have further suggestions.
